### PR TITLE
Implement daily entry workspace with templates and offline queue

### DIFF
--- a/src/app/(protected)/log/page.tsx
+++ b/src/app/(protected)/log/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useMemo } from "react";
+import { DailyEntryForm } from "@/components/daily-entry/DailyEntryForm";
+import { EntryHistory } from "@/components/daily-entry/EntryHistory";
+import { EntryTemplates } from "@/components/daily-entry/EntryTemplates";
+import { useDailyEntry } from "@/components/daily-entry/hooks/useDailyEntry";
+import { useEntryTemplates } from "@/components/daily-entry/hooks/useEntryTemplates";
+import { useSmartSuggestions } from "@/components/daily-entry/hooks/useSmartSuggestions";
+
+const DailyLogPage = () => {
+  const dailyEntry = useDailyEntry();
+  const templateState = useEntryTemplates();
+
+  const activeTemplate = useMemo(() => templateState.activeTemplate, [templateState.activeTemplate]);
+  const { suggestions } = useSmartSuggestions(dailyEntry.entry, dailyEntry.history);
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-8 lg:flex-row">
+      <section className="flex-1 space-y-8">
+        <DailyEntryForm
+          entry={dailyEntry.entry}
+          template={activeTemplate}
+          updateEntry={dailyEntry.updateEntry}
+          upsertSymptom={dailyEntry.upsertSymptom}
+          removeSymptom={dailyEntry.removeSymptom}
+          updateMedication={dailyEntry.updateMedication}
+          toggleMedicationTaken={dailyEntry.toggleMedicationTaken}
+          upsertTrigger={dailyEntry.upsertTrigger}
+          removeTrigger={dailyEntry.removeTrigger}
+          saveEntry={dailyEntry.saveEntry}
+          isSaving={dailyEntry.isSaving}
+          completion={dailyEntry.completion}
+          lastSavedAt={dailyEntry.lastSavedAt}
+          suggestions={suggestions}
+          queueLength={dailyEntry.queue.length}
+          onSyncQueue={dailyEntry.syncQueuedEntries}
+          recentSymptomIds={dailyEntry.recentSymptoms}
+        />
+      </section>
+      <aside className="w-full max-w-sm space-y-6">
+        <EntryTemplates
+          templates={templateState.templates}
+          activeTemplateId={templateState.activeTemplateId}
+          onActivate={templateState.setActiveTemplateId}
+          onCreate={templateState.createTemplate}
+          onUpdate={templateState.updateTemplate}
+          onDelete={templateState.deleteTemplate}
+          onSetDefault={templateState.setDefaultTemplate}
+        />
+        <EntryHistory entries={dailyEntry.history} onSelectEntry={dailyEntry.loadEntry} />
+      </aside>
+    </main>
+  );
+};
+
+export default DailyLogPage;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { CalendarView } from "@/components/calendar/CalendarView";
-import { DailyEntryForm } from "@/components/daily-entry/DailyEntryForm";
 import { SymptomTracker } from "@/components/symptoms/SymptomTracker";
 
 const HomePage = () => {
@@ -67,7 +66,18 @@ const HomePage = () => {
             <SymptomTracker />
           </div>
           <div className="space-y-6 rounded-3xl border border-border bg-card p-6 shadow-sm">
-            <DailyEntryForm />
+            <div className="space-y-3">
+              <h3 className="text-2xl font-semibold text-foreground">Daily entry workspace</h3>
+              <p className="text-sm text-muted-foreground">
+                Visit the daily log to capture health metrics, symptoms, medications, triggers, and notes with smart suggestions and offline support.
+              </p>
+            </div>
+            <Link
+              href="/log"
+              className="inline-flex w-fit items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+            >
+              Open daily log
+            </Link>
           </div>
         </div>
         <div className="rounded-3xl border border-border bg-card p-6 shadow-sm">

--- a/src/components/daily-entry/DailyEntryForm.tsx
+++ b/src/components/daily-entry/DailyEntryForm.tsx
@@ -1,54 +1,242 @@
 "use client";
 
-import { DailyEntry } from "@/lib/types/daily-entry";
-import { useDailyEntry } from "./hooks/useDailyEntry";
+import { useMemo, useState } from "react";
+import { DailyEntry, DailyEntryTemplate } from "@/lib/types/daily-entry";
+import { SYMPTOM_OPTIONS, MEDICATION_OPTIONS, TRIGGER_OPTIONS } from "@/lib/data/daily-entry-presets";
 import { HealthSection } from "./EntrySections/HealthSection";
+import { SymptomSection } from "./EntrySections/SymptomSection";
+import { MedicationSection } from "./EntrySections/MedicationSection";
+import { TriggerSection } from "./EntrySections/TriggerSection";
 import { NotesSection } from "./EntrySections/NotesSection";
+import { QuickEntry } from "./QuickEntry";
+import { SmartSuggestions } from "../daily-entry/SmartSuggestions";
+import { Suggestion } from "./hooks/useSmartSuggestions";
+import { DailyMedication, DailySymptom, DailyTrigger } from "@/lib/types/daily-entry";
 
-export const DailyEntryForm = () => {
-  const { entry, updateEntry } = useDailyEntry();
+interface DailyEntryFormProps {
+  entry: DailyEntry;
+  template: DailyEntryTemplate;
+  updateEntry: (changes: Partial<DailyEntry>) => void;
+  upsertSymptom: (symptomId: string, changes?: Partial<DailySymptom>) => void;
+  removeSymptom: (symptomId: string) => void;
+  updateMedication: (medicationId: string, changes: Partial<DailyMedication>) => void;
+  toggleMedicationTaken: (medicationId: string) => void;
+  upsertTrigger: (triggerId: string, changes?: Partial<DailyTrigger>) => void;
+  removeTrigger: (triggerId: string) => void;
+  saveEntry: () => Promise<void>;
+  isSaving: boolean;
+  completion: number;
+  lastSavedAt: Date | null;
+  suggestions: Suggestion[];
+  queueLength: number;
+  onSyncQueue: () => Promise<void> | void;
+  recentSymptomIds: string[];
+}
 
-  const handleSubmit = () => {
-    // Placeholder submit handler for future integration.
-    console.info("Saving daily entry", entry);
-  };
+const formatLastSaved = (date: Date | null) => {
+  if (!date) return "Not saved yet";
+  return `Last saved ${date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
+};
+
+export const DailyEntryForm = ({
+  entry,
+  template,
+  updateEntry,
+  upsertSymptom,
+  removeSymptom,
+  updateMedication,
+  toggleMedicationTaken,
+  upsertTrigger,
+  removeTrigger,
+  saveEntry,
+  isSaving,
+  completion,
+  lastSavedAt,
+  suggestions,
+  queueLength,
+  onSyncQueue,
+  recentSymptomIds,
+}: DailyEntryFormProps) => {
+  const [mode, setMode] = useState<"full" | "quick">("full");
+
+  const orderedSections = useMemo(
+    () =>
+      [...template.sections].sort((a, b) => a.order - b.order).map((section) => section.type),
+    [template.sections],
+  );
 
   return (
-    <section className="flex flex-col gap-6">
-      <header className="space-y-2">
-        <h2 className="text-2xl font-semibold text-foreground">Daily check-in</h2>
-        <p className="text-sm text-muted-foreground">
-          {"Capture a quick snapshot of how you\u2019re feeling today. Smart suggestions will appear here once data storage is connected."}
-        </p>
-      </header>
-
-      <form
-        className="space-y-6 rounded-2xl border border-border bg-card p-6 shadow-sm"
-        onSubmit={(event) => {
-          event.preventDefault();
-          handleSubmit();
-        }}
-      >
-        <HealthSection
-          overallHealth={entry.overallHealth}
-          energyLevel={entry.energyLevel}
-          sleepQuality={entry.sleepQuality}
-          stressLevel={entry.stressLevel}
-          onChange={(changes: Partial<DailyEntry>) => updateEntry(changes)}
-        />
-        <NotesSection
-          notes={entry.notes ?? ""}
-          onChange={(notes) => updateEntry({ notes })}
-        />
-        <div className="flex justify-end">
+    <section className="space-y-8" aria-label="Daily entry form">
+      <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div className="space-y-1">
+          <h2 className="text-2xl font-semibold text-foreground">Daily check-in</h2>
+          <p className="text-sm text-muted-foreground">
+            Capture a quick snapshot of how you’re feeling today. Smart suggestions help you focus where it matters.
+          </p>
+        </div>
+        <div className="flex items-center gap-3 text-sm">
+          <span className="text-muted-foreground">Mode:</span>
           <button
-            type="submit"
-            className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+            type="button"
+            onClick={() => setMode("full")}
+            className={`rounded-lg px-3 py-1 font-semibold transition-colors ${
+              mode === "full"
+                ? "bg-primary text-primary-foreground"
+                : "border border-border text-foreground hover:border-primary"
+            }`}
           >
-            Save entry
+            Guided
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode("quick")}
+            className={`rounded-lg px-3 py-1 font-semibold transition-colors ${
+              mode === "quick"
+                ? "bg-primary text-primary-foreground"
+                : "border border-border text-foreground hover:border-primary"
+            }`}
+          >
+            Quick
           </button>
         </div>
-      </form>
+      </header>
+
+      <div className="space-y-2">
+        <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-all"
+            style={{ width: `${completion}%` }}
+            role="progressbar"
+            aria-valuenow={completion}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">{completion}% complete · {formatLastSaved(lastSavedAt)}</p>
+      </div>
+
+      {mode === "quick" ? (
+        <QuickEntry
+          entry={entry}
+          suggestions={suggestions}
+          onUpdate={updateEntry}
+          onSubmit={saveEntry}
+          isSaving={isSaving}
+          completion={completion}
+        />
+      ) : (
+        <form
+          className="space-y-6 rounded-2xl border border-border bg-card p-6 shadow-sm"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void saveEntry();
+          }}
+        >
+          {orderedSections.map((section) => {
+            if (section === "health") {
+              return (
+                <HealthSection
+                  key="health"
+                  overallHealth={entry.overallHealth}
+                  energyLevel={entry.energyLevel}
+                  sleepQuality={entry.sleepQuality}
+                  stressLevel={entry.stressLevel}
+                  onChange={updateEntry}
+                />
+              );
+            }
+
+            if (section === "symptoms") {
+              return (
+                <SymptomSection
+                  key="symptoms"
+                  symptoms={entry.symptoms}
+                  availableSymptoms={SYMPTOM_OPTIONS}
+                  recentSymptomIds={recentSymptomIds}
+                  onAddSymptom={(symptomId) => upsertSymptom(symptomId)}
+                  onUpdateSymptom={(symptomId, changes) => upsertSymptom(symptomId, changes)}
+                  onRemoveSymptom={removeSymptom}
+                />
+              );
+            }
+
+            if (section === "medications") {
+              return (
+                <MedicationSection
+                  key="medications"
+                  medications={entry.medications}
+                  schedule={MEDICATION_OPTIONS}
+                  onToggleTaken={toggleMedicationTaken}
+                  onUpdateMedication={updateMedication}
+                />
+              );
+            }
+
+            if (section === "triggers") {
+              return (
+                <TriggerSection
+                  key="triggers"
+                  triggers={entry.triggers}
+                  availableTriggers={TRIGGER_OPTIONS}
+                  onAddTrigger={(triggerId) => upsertTrigger(triggerId)}
+                  onUpdateTrigger={(triggerId, changes) => upsertTrigger(triggerId, changes)}
+                  onRemoveTrigger={removeTrigger}
+                />
+              );
+            }
+
+            if (section === "notes") {
+              return (
+                <NotesSection
+                  key="notes"
+                  notes={entry.notes ?? ""}
+                  mood={entry.mood}
+                  weather={entry.weather}
+                  location={entry.location}
+                  onChange={updateEntry}
+                  onAutoSave={() => {
+                    // Auto-save hook for future persistence integration.
+                  }}
+                />
+              );
+            }
+
+            return null;
+          })}
+
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="text-xs text-muted-foreground">
+              {queueLength > 0
+                ? `${queueLength} entry${queueLength > 1 ? "ies" : ""} will sync when you’re back online.`
+                : "Entries save instantly once submitted."}
+            </div>
+            <div className="flex gap-2">
+              {queueLength > 0 && (
+                <button
+                  type="button"
+                  onClick={() => onSyncQueue()}
+                  className="rounded-lg border border-border px-4 py-2 text-sm font-semibold text-foreground transition-colors hover:border-primary"
+                >
+                  Sync queued entries
+                </button>
+              )}
+              <button
+                type="submit"
+                className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={isSaving}
+              >
+                {isSaving ? "Saving..." : "Save entry"}
+              </button>
+            </div>
+          </div>
+        </form>
+      )}
+
+      <SmartSuggestions
+        suggestions={suggestions}
+        offlineCount={queueLength}
+        onSync={queueLength > 0 ? onSyncQueue : undefined}
+      />
     </section>
   );
 };

--- a/src/components/daily-entry/EntryHistory.tsx
+++ b/src/components/daily-entry/EntryHistory.tsx
@@ -1,7 +1,64 @@
-export const EntryHistory = () => {
+import { DailyEntry } from "@/lib/types/daily-entry";
+
+interface EntryHistoryProps {
+  entries: DailyEntry[];
+  onSelectEntry?: (entry: DailyEntry) => void;
+}
+
+const formatDate = (date: Date) =>
+  date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    weekday: "short",
+  });
+
+export const EntryHistory = ({ entries, onSelectEntry }: EntryHistoryProps) => {
+  if (entries.length === 0) {
+    return (
+      <section className="rounded-2xl border border-dashed border-border bg-muted/30 p-6 text-sm text-muted-foreground">
+        Your recent entries will appear here once you start logging.
+      </section>
+    );
+  }
+
   return (
-    <section className="rounded-2xl border border-dashed border-border bg-muted/30 p-6 text-sm text-muted-foreground">
-      A timeline of past entries will appear here with filtering once calendar integration lands.
+    <section className="space-y-4" aria-label="Recent entries">
+      <header className="space-y-1">
+        <h3 className="text-lg font-semibold text-foreground">Recent entries</h3>
+        <p className="text-sm text-muted-foreground">
+          Use these quick links to review or duplicate a previous day’s entry.
+        </p>
+      </header>
+
+      <ul className="space-y-3">
+        {entries.slice(0, 7).map((entry) => (
+          <li
+            key={entry.id + entry.completedAt.toISOString()}
+            className="flex flex-col gap-2 rounded-xl border border-border bg-background/60 p-4 shadow-sm md:flex-row md:items-center md:justify-between"
+          >
+            <div>
+              <p className="text-sm font-semibold text-foreground">{formatDate(entry.completedAt)}</p>
+              <p className="text-xs text-muted-foreground">
+                Overall {entry.overallHealth}/10 · Energy {entry.energyLevel}/10 · Sleep {entry.sleepQuality}/10
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span>{entry.symptoms.length} symptom{entry.symptoms.length === 1 ? "" : "s"}</span>
+              <span>Triggers: {entry.triggers.length}</span>
+              <span>Medications taken: {entry.medications.filter((med) => med.taken).length}</span>
+              {onSelectEntry && (
+                <button
+                  type="button"
+                  onClick={() => onSelectEntry(entry)}
+                  className="rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition-colors hover:border-primary"
+                >
+                  Use as template
+                </button>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
     </section>
   );
 };

--- a/src/components/daily-entry/EntrySections/MedicationSection.tsx
+++ b/src/components/daily-entry/EntrySections/MedicationSection.tsx
@@ -1,16 +1,96 @@
+"use client";
+
 import { DailyMedication } from "@/lib/types/daily-entry";
+import { MedicationOption } from "@/lib/data/daily-entry-presets";
 
 interface MedicationSectionProps {
   medications: DailyMedication[];
-  onChange: (medications: DailyMedication[]) => void;
+  schedule: MedicationOption[];
+  onToggleTaken: (medicationId: string) => void;
+  onUpdateMedication: (
+    medicationId: string,
+    changes: Partial<DailyMedication>,
+  ) => void;
 }
 
-export const MedicationSection = ({ medications }: MedicationSectionProps) => {
+export const MedicationSection = ({
+  medications,
+  schedule,
+  onToggleTaken,
+  onUpdateMedication,
+}: MedicationSectionProps) => {
   return (
-    <section className="rounded-xl border border-dashed border-border p-4 text-sm text-muted-foreground">
-      {medications.length > 0
-        ? `Medication placeholders: ${medications.length} scheduled.`
-        : "Medication adherence tracking integrates after the medication module is available."}
+    <section className="space-y-4" aria-label="Medication tracking">
+      <header className="space-y-1">
+        <h3 className="text-lg font-semibold text-foreground">Medications</h3>
+        <p className="text-sm text-muted-foreground">
+          Keep your routine on track by checking off what you took today.
+        </p>
+      </header>
+
+      <div className="space-y-4">
+        {schedule.map((medication) => {
+          const entryMedication = medications.find(
+            (item) => item.medicationId === medication.id,
+          );
+          const taken = entryMedication?.taken ?? false;
+
+          return (
+            <div
+              key={medication.id}
+              className="flex flex-col gap-3 rounded-xl border border-border bg-background/60 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div>
+                <p className="font-semibold text-foreground">{medication.name}</p>
+                <p className="text-xs text-muted-foreground">
+                  {medication.dosage} · {medication.schedule}
+                </p>
+              </div>
+
+              <div className="flex flex-1 flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+                <label className="flex items-center gap-2 text-sm font-medium">
+                  <input
+                    type="checkbox"
+                    checked={taken}
+                    onChange={() => onToggleTaken(medication.id)}
+                    className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                  />
+                  Taken today
+                </label>
+
+                <label className="flex flex-1 flex-col gap-2 text-sm">
+                  <span className="font-medium text-foreground">Dosage</span>
+                  <input
+                    type="text"
+                    value={entryMedication?.dosage ?? medication.dosage}
+                    onChange={(event) =>
+                      onUpdateMedication(medication.id, {
+                        dosage: event.target.value,
+                      })
+                    }
+                    className="w-full rounded-lg border border-border bg-background px-3 py-2"
+                  />
+                </label>
+
+                <label className="flex flex-1 flex-col gap-2 text-sm">
+                  <span className="font-medium text-foreground">Notes</span>
+                  <input
+                    type="text"
+                    value={entryMedication?.notes ?? ""}
+                    onChange={(event) =>
+                      onUpdateMedication(medication.id, {
+                        notes: event.target.value,
+                      })
+                    }
+                    placeholder="Side effects, reminders, or adjustments"
+                    className="w-full rounded-lg border border-border bg-background px-3 py-2"
+                  />
+                </label>
+              </div>
+            </div>
+          );
+        })}
+      </div>
     </section>
   );
 };

--- a/src/components/daily-entry/EntrySections/NotesSection.tsx
+++ b/src/components/daily-entry/EntrySections/NotesSection.tsx
@@ -1,20 +1,255 @@
 "use client";
 
+import { useEffect, useMemo, useRef, useState } from "react";
+import { DailyEntry, WeatherData } from "@/lib/types/daily-entry";
+import { MOOD_OPTIONS } from "@/lib/data/daily-entry-presets";
+
 interface NotesSectionProps {
   notes: string;
-  onChange: (notes: string) => void;
+  mood?: string;
+  weather?: WeatherData;
+  location?: string;
+  onChange: (changes: Partial<DailyEntry>) => void;
+  onAutoSave?: () => void;
 }
 
-export const NotesSection = ({ notes, onChange }: NotesSectionProps) => {
+const formatRelativeTime = (date: Date) => {
+  const diffInSeconds = Math.round((Date.now() - date.getTime()) / 1000);
+  if (diffInSeconds < 5) return "just now";
+  if (diffInSeconds < 60) return `${diffInSeconds} seconds ago`;
+  const diffInMinutes = Math.round(diffInSeconds / 60);
+  return diffInMinutes === 1 ? "a minute ago" : `${diffInMinutes} minutes ago`;
+};
+
+export const NotesSection = ({
+  notes,
+  mood,
+  weather,
+  location,
+  onChange,
+  onAutoSave,
+}: NotesSectionProps) => {
+  const [notesValue, setNotesValue] = useState(notes);
+  const [lastAutoSave, setLastAutoSave] = useState<Date | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    setNotesValue(notes);
+  }, [notes]);
+
+  useEffect(() => {
+    if (!onAutoSave) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setLastAutoSave(new Date());
+      onAutoSave();
+    }, 1200);
+
+    return () => window.clearTimeout(timer);
+  }, [notesValue, mood, weather, location, onAutoSave]);
+
+  const applyFormatting = (wrapper: string) => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    const { selectionStart, selectionEnd, value } = textarea;
+    const selected = value.slice(selectionStart, selectionEnd) || "text";
+    const wrapped = `${wrapper}${selected}${wrapper}`;
+    const nextValue = `${value.slice(0, selectionStart)}${wrapped}${value.slice(selectionEnd)}`;
+
+    setNotesValue(nextValue);
+    onChange({ notes: nextValue });
+
+    requestAnimationFrame(() => {
+      textarea.focus();
+      const cursorStart = selectionStart + wrapper.length;
+      const cursorEnd = cursorStart + selected.length;
+      textarea.setSelectionRange(cursorStart, cursorEnd);
+    });
+  };
+
+  const insertBullet = () => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    const { selectionStart, selectionEnd, value } = textarea;
+    const selected = value.slice(selectionStart, selectionEnd);
+    const lines = selected.split("\n").map((line) => (line.startsWith("- ") ? line : `- ${line || "item"}`));
+    const nextValue = `${value.slice(0, selectionStart)}${lines.join("\n")}${value.slice(selectionEnd)}`;
+
+    setNotesValue(nextValue);
+    onChange({ notes: nextValue });
+
+    requestAnimationFrame(() => {
+      textarea.focus();
+      const cursor = selectionStart + 2;
+      textarea.setSelectionRange(cursor, cursor + lines[0].length - 2);
+    });
+  };
+
+  const handleWeatherChange = (key: keyof WeatherData, value: number | string | undefined) => {
+    const updatedWeather: WeatherData = {
+      ...(weather ?? {}),
+      [key]: value,
+    };
+
+    if (
+      updatedWeather.temperatureCelsius === undefined &&
+      updatedWeather.humidity === undefined &&
+      !updatedWeather.conditions
+    ) {
+      onChange({ weather: undefined });
+    } else {
+      onChange({ weather: updatedWeather });
+    }
+  };
+
+  const moodToneClass = useMemo(() => {
+    const option = MOOD_OPTIONS.find((item) => item.id === mood);
+    if (!option) return "bg-muted text-muted-foreground";
+    if (option.tone === "positive") return "bg-emerald-100 text-emerald-900";
+    if (option.tone === "neutral") return "bg-blue-100 text-blue-900";
+    return "bg-amber-100 text-amber-900";
+  }, [mood]);
+
   return (
-    <label className="flex flex-col gap-2 text-sm">
-      <span className="font-medium text-foreground">Notes</span>
-      <textarea
-        value={notes}
-        onChange={(event) => onChange(event.target.value)}
-        placeholder="Add context about today's health, triggers, or wins."
-        className="min-h-32 rounded-lg border border-border bg-background px-4 py-3"
-      />
-    </label>
+    <section className="space-y-4" aria-label="Notes and additional context">
+      <header className="space-y-1">
+        <h3 className="text-lg font-semibold text-foreground">Notes & context</h3>
+        <p className="text-sm text-muted-foreground">
+          Capture wins, stressors, weather, or anything else that helps tell the story of today.
+        </p>
+      </header>
+
+      <div className="flex flex-wrap gap-2">
+        {MOOD_OPTIONS.map((option) => {
+          const isActive = option.id === mood;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => onChange({ mood: option.id })}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                isActive
+                  ? moodToneClass
+                  : "border border-border bg-background text-muted-foreground hover:border-primary/60"
+              }`}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          onClick={() => onChange({ mood: undefined })}
+          className="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground hover:border-primary/60"
+        >
+          Clear mood
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-3 rounded-xl border border-border bg-background/60 p-4 shadow-sm">
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">Formatting</span>
+          <button
+            type="button"
+            onClick={() => applyFormatting("**")}
+            className="rounded border border-border px-2 py-1"
+          >
+            Bold
+          </button>
+          <button
+            type="button"
+            onClick={() => applyFormatting("*")}
+            className="rounded border border-border px-2 py-1"
+          >
+            Italic
+          </button>
+          <button
+            type="button"
+            onClick={insertBullet}
+            className="rounded border border-border px-2 py-1"
+          >
+            Bullet list
+          </button>
+          {lastAutoSave && (
+            <span className="ml-auto text-[11px] uppercase tracking-wide">
+              Auto-saved {formatRelativeTime(lastAutoSave)}
+            </span>
+          )}
+        </div>
+
+        <textarea
+          ref={textareaRef}
+          value={notesValue}
+          onChange={(event) => {
+            setNotesValue(event.target.value);
+            onChange({ notes: event.target.value });
+          }}
+          placeholder="Add reflections, coping strategies, or wins from today. Markdown formatting is supported."
+          className="min-h-40 rounded-lg border border-border bg-background px-4 py-3 text-sm leading-relaxed"
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="font-medium text-foreground">Location</span>
+          <input
+            type="text"
+            value={location ?? ""}
+            onChange={(event) => onChange({ location: event.target.value })}
+            placeholder="Home, work, travel..."
+            className="rounded-lg border border-border bg-background px-3 py-2"
+          />
+        </label>
+
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="font-medium text-foreground">Temperature (°C)</span>
+          <input
+            type="number"
+            value={weather?.temperatureCelsius ?? ""}
+            onChange={(event) =>
+              handleWeatherChange(
+                "temperatureCelsius",
+                event.target.value ? Number(event.target.value) : undefined,
+              )
+            }
+            className="rounded-lg border border-border bg-background px-3 py-2"
+          />
+        </label>
+
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="font-medium text-foreground">Humidity (%)</span>
+          <input
+            type="number"
+            value={weather?.humidity ?? ""}
+            onChange={(event) =>
+              handleWeatherChange(
+                "humidity",
+                event.target.value ? Number(event.target.value) : undefined,
+              )
+            }
+            className="rounded-lg border border-border bg-background px-3 py-2"
+          />
+        </label>
+      </div>
+
+      <label className="flex flex-col gap-2 text-sm md:w-1/2">
+        <span className="font-medium text-foreground">Conditions</span>
+        <input
+          type="text"
+          value={weather?.conditions ?? ""}
+          onChange={(event) => handleWeatherChange("conditions", event.target.value || undefined)}
+          placeholder="Sunny, rainy, windy..."
+          className="rounded-lg border border-border bg-background px-3 py-2"
+        />
+      </label>
+    </section>
   );
 };

--- a/src/components/daily-entry/EntrySections/SymptomSection.tsx
+++ b/src/components/daily-entry/EntrySections/SymptomSection.tsx
@@ -1,16 +1,206 @@
+"use client";
+
+import { useMemo, useState } from "react";
 import { DailySymptom } from "@/lib/types/daily-entry";
+import { SymptomOption } from "@/lib/data/daily-entry-presets";
 
 interface SymptomSectionProps {
   symptoms: DailySymptom[];
-  onChange: (symptoms: DailySymptom[]) => void;
+  availableSymptoms: SymptomOption[];
+  recentSymptomIds: string[];
+  onAddSymptom: (symptomId: string) => void;
+  onUpdateSymptom: (
+    symptomId: string,
+    changes: Partial<DailySymptom>,
+  ) => void;
+  onRemoveSymptom: (symptomId: string) => void;
 }
 
-export const SymptomSection = ({ symptoms }: SymptomSectionProps) => {
+const severityLabel = (value: number) => {
+  if (value <= 2) return "Mild";
+  if (value <= 6) return "Moderate";
+  return "Severe";
+};
+
+export const SymptomSection = ({
+  symptoms,
+  availableSymptoms,
+  recentSymptomIds,
+  onAddSymptom,
+  onUpdateSymptom,
+  onRemoveSymptom,
+}: SymptomSectionProps) => {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedSymptom, setSelectedSymptom] = useState<string>("");
+
+  const filteredOptions = useMemo(() => {
+    const normalized = searchTerm.trim().toLowerCase();
+    return availableSymptoms.filter((option) =>
+      option.label.toLowerCase().includes(normalized),
+    );
+  }, [availableSymptoms, searchTerm]);
+
+  const quickSymptomOptions = useMemo(
+    () =>
+      recentSymptomIds
+        .map((symptomId) =>
+          availableSymptoms.find((option) => option.id === symptomId),
+        )
+        .filter((option): option is SymptomOption => Boolean(option)),
+    [availableSymptoms, recentSymptomIds],
+  );
+
+  const handleAddSymptom = (symptomId: string) => {
+    onAddSymptom(symptomId);
+    setSelectedSymptom("");
+    setSearchTerm("");
+  };
+
   return (
-    <section className="rounded-xl border border-dashed border-border p-4 text-sm text-muted-foreground">
-      {symptoms.length > 0
-        ? `Symptom placeholders: ${symptoms.length} selected.`
-        : "Symptom logging will appear here after the symptom tracker is connected."}
+    <section className="space-y-4" aria-label="Symptom tracking">
+      <header className="space-y-1">
+        <h3 className="text-lg font-semibold text-foreground">Symptoms</h3>
+        <p className="text-sm text-muted-foreground">
+          Track what you felt today so we can surface correlations in your timeline.
+        </p>
+      </header>
+
+      {quickSymptomOptions.length > 0 && (
+        <div className="flex flex-wrap gap-2" aria-label="Recent symptoms">
+          {quickSymptomOptions.map((option) => {
+            const isActive = symptoms.some(
+              (symptom) => symptom.symptomId === option.id,
+            );
+            return (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => handleAddSymptom(option.id)}
+                className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                  isActive
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-border bg-muted text-muted-foreground hover:border-primary/60"
+                }`}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="flex-1">
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="font-medium text-foreground">Add symptom</span>
+            <input
+              type="text"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Search symptoms"
+              className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+            />
+          </label>
+        </div>
+        <div className="w-full sm:w-48">
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="font-medium text-foreground">Choose</span>
+            <select
+              value={selectedSymptom}
+              onChange={(event) => setSelectedSymptom(event.target.value)}
+              className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+            >
+              <option value="">Select</option>
+              {filteredOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <button
+          type="button"
+          onClick={() => selectedSymptom && handleAddSymptom(selectedSymptom)}
+          className="self-end rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+          disabled={!selectedSymptom}
+        >
+          Add
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        {symptoms.length === 0 && (
+          <p className="rounded-lg border border-dashed border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+            No symptoms logged yet. Use the search or quick picks above to begin tracking.
+          </p>
+        )}
+
+        {symptoms.map((symptom) => {
+          const option = availableSymptoms.find(
+            (item) => item.id === symptom.symptomId,
+          );
+          return (
+            <div
+              key={symptom.symptomId}
+              className="space-y-3 rounded-xl border border-border bg-background/60 p-4 shadow-sm"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="font-semibold text-foreground">
+                    {option?.label ?? symptom.symptomId}
+                  </p>
+                  {option?.category && (
+                    <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                      {option.category}
+                    </p>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onRemoveSymptom(symptom.symptomId)}
+                  className="text-xs font-medium text-muted-foreground transition-colors hover:text-destructive"
+                >
+                  Remove
+                </button>
+              </div>
+
+              <label className="flex flex-col gap-2 text-sm">
+                <span className="font-medium text-foreground">Severity</span>
+                <input
+                  type="range"
+                  min={0}
+                  max={10}
+                  value={symptom.severity}
+                  onChange={(event) =>
+                    onUpdateSymptom(symptom.symptomId, {
+                      severity: Number(event.target.value),
+                    })
+                  }
+                  className="h-2 w-full cursor-pointer rounded-full bg-muted"
+                />
+                <span className="text-xs text-muted-foreground">
+                  {symptom.severity} / 10 ({severityLabel(symptom.severity)})
+                </span>
+              </label>
+
+              <label className="flex flex-col gap-2 text-sm">
+                <span className="font-medium text-foreground">Notes</span>
+                <textarea
+                  value={symptom.notes ?? ""}
+                  onChange={(event) =>
+                    onUpdateSymptom(symptom.symptomId, {
+                      notes: event.target.value,
+                    })
+                  }
+                  placeholder="Add context, duration, or what helped."
+                  className="min-h-20 rounded-lg border border-border bg-background px-3 py-2"
+                />
+              </label>
+            </div>
+          );
+        })}
+      </div>
     </section>
   );
 };

--- a/src/components/daily-entry/EntrySections/TriggerSection.tsx
+++ b/src/components/daily-entry/EntrySections/TriggerSection.tsx
@@ -1,16 +1,192 @@
+"use client";
+
+import { useMemo, useState } from "react";
 import { DailyTrigger } from "@/lib/types/daily-entry";
+import { TriggerOption } from "@/lib/data/daily-entry-presets";
 
 interface TriggerSectionProps {
   triggers: DailyTrigger[];
-  onChange: (triggers: DailyTrigger[]) => void;
+  availableTriggers: TriggerOption[];
+  onAddTrigger: (triggerId: string) => void;
+  onUpdateTrigger: (
+    triggerId: string,
+    changes: Partial<DailyTrigger>,
+  ) => void;
+  onRemoveTrigger: (triggerId: string) => void;
 }
 
-export const TriggerSection = ({ triggers }: TriggerSectionProps) => {
+const intensityLabel = (value: number) => {
+  if (value <= 3) return "Low";
+  if (value <= 6) return "Moderate";
+  return "High";
+};
+
+export const TriggerSection = ({
+  triggers,
+  availableTriggers,
+  onAddTrigger,
+  onUpdateTrigger,
+  onRemoveTrigger,
+}: TriggerSectionProps) => {
+  const [selectedTrigger, setSelectedTrigger] = useState<string>("");
+
+  const unusedTriggers = useMemo(
+    () =>
+      availableTriggers.filter(
+        (trigger) => !triggers.some((item) => item.triggerId === trigger.id),
+      ),
+    [availableTriggers, triggers],
+  );
+
+  const correlationHints = useMemo(() => {
+    return triggers.map((trigger) => {
+      if (trigger.intensity >= 7) {
+        return {
+          triggerId: trigger.triggerId,
+          message: "High intensity today. Check your notes for potential mitigation steps.",
+        };
+      }
+
+      if (trigger.intensity <= 3) {
+        return {
+          triggerId: trigger.triggerId,
+          message: "Lower than usual. Celebrate what helped keep this trigger in check!",
+        };
+      }
+
+      return {
+        triggerId: trigger.triggerId,
+        message: "Steady intensity. Keep logging to surface weekly trends.",
+      };
+    });
+  }, [triggers]);
+
   return (
-    <section className="rounded-xl border border-dashed border-border p-4 text-sm text-muted-foreground">
-      {triggers.length > 0
-        ? `Trigger placeholders: ${triggers.length} tracked.`
-        : "Trigger tracking will allow quick intensity sliders tied to your custom triggers."}
+    <section className="space-y-4" aria-label="Trigger logging">
+      <header className="space-y-1">
+        <h3 className="text-lg font-semibold text-foreground">Triggers</h3>
+        <p className="text-sm text-muted-foreground">
+          Spot what may be contributing to good or tough days with quick trigger tracking.
+        </p>
+      </header>
+
+      <div className="rounded-xl border border-dashed border-border bg-muted/30 p-4 text-xs text-muted-foreground">
+        <p className="font-medium text-foreground">Need ideas?</p>
+        <p>Look for:</p>
+        <ul className="list-disc space-y-1 pl-5">
+          <li>Weather shifts or seasonal changes</li>
+          <li>Stressful conversations or deadlines</li>
+          <li>Diet changes, hydration, or caffeine</li>
+          <li>Sleep disruptions or late nights</li>
+        </ul>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+        <label className="flex flex-1 flex-col gap-2 text-sm">
+          <span className="font-medium text-foreground">Add trigger</span>
+          <select
+            value={selectedTrigger}
+            onChange={(event) => setSelectedTrigger(event.target.value)}
+            className="rounded-lg border border-border bg-background px-3 py-2"
+          >
+            <option value="">Select trigger</option>
+            {unusedTriggers.map((trigger) => (
+              <option key={trigger.id} value={trigger.id}>
+                {trigger.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          onClick={() => selectedTrigger && onAddTrigger(selectedTrigger)}
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+          disabled={!selectedTrigger}
+        >
+          Add
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        {triggers.length === 0 && (
+          <p className="rounded-lg border border-dashed border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+            Log a trigger whenever you notice something that may influence how you feel.
+          </p>
+        )}
+
+        {triggers.map((trigger) => {
+          const option = availableTriggers.find(
+            (item) => item.id === trigger.triggerId,
+          );
+          const hint = correlationHints.find(
+            (item) => item.triggerId === trigger.triggerId,
+          );
+
+          return (
+            <div
+              key={trigger.triggerId}
+              className="space-y-3 rounded-xl border border-border bg-background/60 p-4 shadow-sm"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="font-semibold text-foreground">
+                    {option?.label ?? trigger.triggerId}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {option?.description ?? "Custom trigger"}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onRemoveTrigger(trigger.triggerId)}
+                  className="text-xs font-medium text-muted-foreground transition-colors hover:text-destructive"
+                >
+                  Remove
+                </button>
+              </div>
+
+              <label className="flex flex-col gap-2 text-sm">
+                <span className="font-medium text-foreground">Intensity</span>
+                <input
+                  type="range"
+                  min={0}
+                  max={10}
+                  value={trigger.intensity}
+                  onChange={(event) =>
+                    onUpdateTrigger(trigger.triggerId, {
+                      intensity: Number(event.target.value),
+                    })
+                  }
+                  className="h-2 w-full cursor-pointer rounded-full bg-muted"
+                />
+                <span className="text-xs text-muted-foreground">
+                  {trigger.intensity} / 10 ({intensityLabel(trigger.intensity)})
+                </span>
+              </label>
+
+              <label className="flex flex-col gap-2 text-sm">
+                <span className="font-medium text-foreground">Notes</span>
+                <textarea
+                  value={trigger.notes ?? ""}
+                  onChange={(event) =>
+                    onUpdateTrigger(trigger.triggerId, {
+                      notes: event.target.value,
+                    })
+                  }
+                  placeholder="What happened, how long it lasted, or what helped"
+                  className="min-h-20 rounded-lg border border-border bg-background px-3 py-2"
+                />
+              </label>
+
+              {hint && (
+                <div className="rounded-lg border border-dashed border-primary/40 bg-primary/5 p-3 text-xs text-primary">
+                  {hint.message}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
     </section>
   );
 };

--- a/src/components/daily-entry/EntryTemplates.tsx
+++ b/src/components/daily-entry/EntryTemplates.tsx
@@ -1,7 +1,285 @@
-export const EntryTemplates = () => {
+"use client";
+
+import { useMemo, useState } from "react";
+import { DailyEntryTemplate } from "@/lib/types/daily-entry";
+import { TemplateDraft, TemplateSectionType } from "./hooks/useEntryTemplates";
+
+interface EntryTemplatesProps {
+  templates: DailyEntryTemplate[];
+  activeTemplateId: string;
+  onActivate: (templateId: string) => void;
+  onCreate: (draft: TemplateDraft) => void;
+  onUpdate: (templateId: string, draft: Partial<TemplateDraft>) => void;
+  onDelete: (templateId: string) => void;
+  onSetDefault: (templateId: string) => void;
+}
+
+const SECTION_OPTIONS: Array<{ type: TemplateSectionType; label: string }> = [
+  { type: "health", label: "Health metrics" },
+  { type: "symptoms", label: "Symptoms" },
+  { type: "medications", label: "Medications" },
+  { type: "triggers", label: "Triggers" },
+  { type: "notes", label: "Notes & context" },
+];
+
+const ensureRequiredSections = (sections: TemplateSectionType[]) => {
+  const merged = new Set<TemplateSectionType>(sections);
+  merged.add("health");
+  merged.add("symptoms");
+  return Array.from(merged);
+};
+
+const renderSectionsList = (
+  sections: TemplateSectionType[],
+  onChange: (next: TemplateSectionType[]) => void,
+) => (
+  <div className="flex flex-wrap gap-2">
+    {SECTION_OPTIONS.map((option) => {
+      const isChecked = sections.includes(option.type);
+      return (
+        <label
+          key={option.type}
+          className={`flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+            isChecked
+              ? "border-primary bg-primary/10 text-primary"
+              : "border-border text-muted-foreground hover:border-primary/60"
+          }`}
+        >
+          <input
+            type="checkbox"
+            checked={isChecked}
+            onChange={() => {
+              const next = isChecked
+                ? sections.filter((section) => section !== option.type)
+                : [...sections, option.type];
+              onChange(next);
+            }}
+            className="hidden"
+          />
+          {option.label}
+        </label>
+      );
+    })}
+  </div>
+);
+
+export const EntryTemplates = ({
+  templates,
+  activeTemplateId,
+  onActivate,
+  onCreate,
+  onUpdate,
+  onDelete,
+  onSetDefault,
+}: EntryTemplatesProps) => {
+  const [name, setName] = useState("Weekend check-in");
+  const [selectedSections, setSelectedSections] = useState<TemplateSectionType[]>([
+    "health",
+    "symptoms",
+    "notes",
+  ]);
+  const [editingTemplate, setEditingTemplate] = useState<string | null>(null);
+  const [editSections, setEditSections] = useState<TemplateSectionType[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const activeTemplate = useMemo(
+    () => templates.find((template) => template.id === activeTemplateId),
+    [templates, activeTemplateId],
+  );
+
+  const handleCreateTemplate = () => {
+    if (!name.trim()) {
+      setError("Template name is required");
+      return;
+    }
+
+    setError(null);
+    onCreate({ name: name.trim(), sectionTypes: ensureRequiredSections(selectedSections) });
+    setName("Custom template");
+    setSelectedSections(["health", "symptoms"]);
+  };
+
+  const beginEditing = (template: DailyEntryTemplate) => {
+    setEditingTemplate(template.id);
+    setEditSections(template.sections.map((section) => section.type));
+  };
+
+  const commitEdit = () => {
+    if (!editingTemplate) {
+      return;
+    }
+
+    onUpdate(editingTemplate, {
+      name:
+        templates.find((template) => template.id === editingTemplate)?.name ??
+        "Template",
+      sectionTypes: ensureRequiredSections(editSections),
+    });
+    setEditingTemplate(null);
+    setEditSections([]);
+  };
+
   return (
-    <section className="rounded-2xl border border-dashed border-border bg-muted/30 p-6 text-sm text-muted-foreground">
-      Template management will let you create quick logging presets once data storage is ready.
+    <section className="space-y-6" aria-label="Entry templates">
+      <header className="space-y-1">
+        <h3 className="text-lg font-semibold text-foreground">Templates</h3>
+        <p className="text-sm text-muted-foreground">
+          Customize what you track each day. Required sections are automatically included.
+        </p>
+      </header>
+
+      <div className="space-y-3 rounded-2xl border border-border bg-background/60 p-4 shadow-sm">
+        <h4 className="text-sm font-semibold text-foreground">Create template</h4>
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="font-medium text-foreground">Name</span>
+            <input
+              type="text"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className="rounded-lg border border-border bg-background px-3 py-2"
+              placeholder="Name your template"
+            />
+          </label>
+
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Sections
+            </p>
+            {renderSectionsList(selectedSections, setSelectedSections)}
+            <p className="text-xs text-muted-foreground">
+              Health metrics and symptoms are always included to maintain data quality.
+            </p>
+          </div>
+
+          {error && <p className="text-xs text-destructive">{error}</p>}
+
+          <button
+            type="button"
+            onClick={handleCreateTemplate}
+            className="self-start rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+          >
+            Save template
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Your templates
+        </h4>
+        <ul className="space-y-3">
+          {templates.map((template) => {
+            const isEditing = editingTemplate === template.id;
+            return (
+              <li
+                key={template.id}
+                className={`space-y-3 rounded-2xl border p-4 shadow-sm transition-colors ${
+                  template.id === activeTemplateId
+                    ? "border-primary bg-primary/5"
+                    : "border-border bg-background/60"
+                }`}
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">{template.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      Created {template.createdAt.toLocaleDateString()}
+                    </p>
+                  </div>
+                  {template.isDefault && (
+                    <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-primary">
+                      Default
+                    </span>
+                  )}
+                  {template.id === activeTemplate?.id && (
+                    <span className="rounded-full bg-sky-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-sky-900">
+                      Active
+                    </span>
+                  )}
+                </div>
+
+                <div className="space-y-2 text-xs text-muted-foreground">
+                  <p className="font-medium text-foreground">Sections</p>
+                  <div className="flex flex-wrap gap-2">
+                    {template.sections.map((section) => (
+                      <span
+                        key={section.type}
+                        className="rounded-full border border-border px-3 py-1 text-[11px] font-medium text-muted-foreground"
+                      >
+                        {SECTION_OPTIONS.find((option) => option.type === section.type)?.label ?? section.type}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                {isEditing && (
+                  <div className="space-y-3 rounded-lg border border-dashed border-border bg-muted/20 p-3">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Customize sections
+                    </p>
+                    {renderSectionsList(editSections, setEditSections)}
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={commitEdit}
+                        className="rounded-lg bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground"
+                      >
+                        Save changes
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setEditingTemplate(null);
+                          setEditSections([]);
+                        }}
+                        className="rounded-lg border border-border px-3 py-2 text-xs font-semibold text-muted-foreground"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                  <button
+                    type="button"
+                    onClick={() => onActivate(template.id)}
+                    className="rounded-md border border-border px-3 py-1 font-semibold text-foreground transition-colors hover:border-primary"
+                  >
+                    Use template
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => beginEditing(template)}
+                    className="rounded-md border border-border px-3 py-1 font-semibold text-foreground transition-colors hover:border-primary"
+                  >
+                    Edit
+                  </button>
+                  {!template.isDefault && (
+                    <button
+                      type="button"
+                      onClick={() => onSetDefault(template.id)}
+                      className="rounded-md border border-border px-3 py-1 font-semibold text-foreground transition-colors hover:border-primary"
+                    >
+                      Make default
+                    </button>
+                  )}
+                  {!template.isDefault && (
+                    <button
+                      type="button"
+                      onClick={() => onDelete(template.id)}
+                      className="rounded-md border border-destructive px-3 py-1 font-semibold text-destructive transition-colors hover:bg-destructive/10"
+                    >
+                      Delete
+                    </button>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
     </section>
   );
 };

--- a/src/components/daily-entry/QuickEntry.tsx
+++ b/src/components/daily-entry/QuickEntry.tsx
@@ -1,7 +1,148 @@
-export const QuickEntry = () => {
+"use client";
+
+import { useState } from "react";
+import { DailyEntry } from "@/lib/types/daily-entry";
+import { Suggestion } from "./hooks/useSmartSuggestions";
+
+interface QuickEntryProps {
+  entry: DailyEntry;
+  suggestions: Suggestion[];
+  onUpdate: (changes: Partial<DailyEntry>) => void;
+  onSubmit: () => Promise<void>;
+  isSaving: boolean;
+  completion: number;
+}
+
+const QUICK_VALUES = [2, 5, 8];
+type MetricKey = keyof Pick<DailyEntry, "overallHealth" | "energyLevel" | "sleepQuality" | "stressLevel">;
+const QUICK_METRICS: MetricKey[] = [
+  "overallHealth",
+  "energyLevel",
+  "sleepQuality",
+  "stressLevel",
+];
+
+export const QuickEntry = ({
+  entry,
+  suggestions,
+  onUpdate,
+  onSubmit,
+  isSaving,
+  completion,
+}: QuickEntryProps) => {
+  const [status, setStatus] = useState<string | null>(null);
+
+  const handleQuickSet = (key: MetricKey, value: number) => {
+    onUpdate({ [key]: value } as Partial<DailyEntry>);
+    setStatus("Updated");
+    window.setTimeout(() => setStatus(null), 1000);
+  };
+
+  const handleSubmit = async () => {
+    setStatus("Saving...");
+    await onSubmit();
+    setStatus("Saved!");
+    window.setTimeout(() => setStatus(null), 1500);
+  };
+
   return (
-    <section className="rounded-2xl border border-dashed border-border bg-muted/30 p-6 text-sm text-muted-foreground">
-      Quick entry mode will surface a condensed form tailored to your most-used fields.
+    <section className="space-y-4" aria-label="Quick entry mode">
+      <header className="space-y-1">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="text-lg font-semibold text-foreground">Quick entry</h3>
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {completion}% complete
+          </span>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Tap a value to adjust today’s metrics. Perfect for logging in under 30 seconds.
+        </p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {QUICK_METRICS.map((metric) => {
+          const current = entry[metric];
+          const label =
+            metric === "overallHealth"
+              ? "Overall health"
+              : metric === "energyLevel"
+                ? "Energy"
+                : metric === "sleepQuality"
+                  ? "Sleep"
+                  : "Stress";
+
+          return (
+            <div
+              key={metric}
+              className="space-y-3 rounded-xl border border-border bg-background/60 p-4 shadow-sm"
+            >
+              <div className="flex items-center justify-between text-sm font-medium text-foreground">
+                <span>{label}</span>
+                <span className="text-xs text-muted-foreground">{current} / 10</span>
+              </div>
+              <div className="flex gap-2">
+                {QUICK_VALUES.map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => handleQuickSet(metric, value)}
+                    className={`flex-1 rounded-lg border px-3 py-2 text-sm font-semibold transition-colors ${
+                      current === value
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border text-foreground hover:border-primary"
+                    }`}
+                  >
+                    {value}
+                  </button>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Smart nudges
+        </p>
+        <ul className="space-y-2">
+          {suggestions.map((suggestion) => (
+            <li
+              key={suggestion.id}
+              className={`rounded-lg border px-3 py-2 text-sm ${
+                suggestion.type === "encouragement"
+                  ? "border-emerald-200 bg-emerald-50 text-emerald-900"
+                  : suggestion.type === "reminder"
+                    ? "border-amber-200 bg-amber-50 text-amber-900"
+                    : "border-sky-200 bg-sky-50 text-sky-900"
+              }`}
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <span>{suggestion.message}</span>
+                {suggestion.actionLabel && (
+                  <span className="rounded-full bg-white/70 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide">
+                    {suggestion.actionLabel}
+                  </span>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs text-muted-foreground">
+          {status ?? "Changes save automatically when you submit."}
+        </span>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={isSaving}
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSaving ? "Saving..." : "Log day"}
+        </button>
+      </div>
     </section>
   );
 };

--- a/src/components/daily-entry/SmartSuggestions.tsx
+++ b/src/components/daily-entry/SmartSuggestions.tsx
@@ -1,7 +1,68 @@
-export const SmartSuggestions = () => {
+import { Suggestion } from "./hooks/useSmartSuggestions";
+
+interface SmartSuggestionsProps {
+  suggestions: Suggestion[];
+  offlineCount: number;
+  onSync?: () => void;
+}
+
+export const SmartSuggestions = ({
+  suggestions,
+  offlineCount,
+  onSync,
+}: SmartSuggestionsProps) => {
   return (
-    <section className="rounded-2xl border border-dashed border-border bg-muted/30 p-6 text-sm text-muted-foreground">
-      Personalized suggestions will populate here after we connect the analytics engine in Phase 3.
+    <section className="space-y-4" aria-label="Personalized suggestions">
+      <header className="space-y-1">
+        <h3 className="text-lg font-semibold text-foreground">Smart suggestions</h3>
+        <p className="text-sm text-muted-foreground">
+          Insights based on today’s log and your recent history.
+        </p>
+      </header>
+
+      <ul className="space-y-3">
+        {suggestions.map((suggestion) => (
+          <li
+            key={suggestion.id}
+            className={`rounded-xl border px-4 py-3 text-sm leading-relaxed ${
+              suggestion.type === "encouragement"
+                ? "border-emerald-200 bg-emerald-50 text-emerald-900"
+                : suggestion.type === "reminder"
+                  ? "border-amber-200 bg-amber-50 text-amber-900"
+                  : "border-sky-200 bg-sky-50 text-sky-900"
+            }`}
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span>{suggestion.message}</span>
+              {suggestion.actionLabel && (
+                <span className="rounded-full bg-white/60 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide">
+                  {suggestion.actionLabel}
+                </span>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {offlineCount > 0 && (
+        <div className="rounded-lg border border-dashed border-border bg-muted/30 p-3 text-xs text-muted-foreground">
+          <p className="font-medium text-foreground">
+            {offlineCount} entry{offlineCount > 1 ? "ies" : ""} waiting to sync.
+          </p>
+          <p>
+            We’ll automatically upload them when you’re back online. {onSync && "You can also sync manually now."}
+          </p>
+          {onSync && (
+            <button
+              type="button"
+              onClick={onSync}
+              className="mt-2 rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition-colors hover:border-primary"
+            >
+              Sync now
+            </button>
+          )}
+        </div>
+      )}
     </section>
   );
 };

--- a/src/components/daily-entry/hooks/useDailyEntry.ts
+++ b/src/components/daily-entry/hooks/useDailyEntry.ts
@@ -1,10 +1,32 @@
 "use client";
 
-import { useState } from "react";
-import { DailyEntry } from "@/lib/types/daily-entry";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  DailyEntry,
+  DailyMedication,
+  DailySymptom,
+  DailyTrigger,
+} from "@/lib/types/daily-entry";
+import {
+  MEDICATION_OPTIONS,
+  SYMPTOM_OPTIONS,
+} from "@/lib/data/daily-entry-presets";
+
+const OFFLINE_QUEUE_KEY = "pst-offline-entry-queue";
+const HISTORY_KEY = "pst-entry-history";
+
+const serializeEntry = (entry: DailyEntry) => ({
+  ...entry,
+  completedAt: entry.completedAt.toISOString(),
+});
+
+const deserializeEntry = (entry: ReturnType<typeof serializeEntry>): DailyEntry => ({
+  ...entry,
+  completedAt: new Date(entry.completedAt),
+});
 
 const createInitialEntry = (): DailyEntry => ({
-  id: crypto.randomUUID(),
+  id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`,
   userId: "demo",
   date: new Date().toISOString().slice(0, 10),
   overallHealth: 5,
@@ -12,22 +34,371 @@ const createInitialEntry = (): DailyEntry => ({
   sleepQuality: 5,
   stressLevel: 5,
   symptoms: [],
-  medications: [],
+  medications: MEDICATION_OPTIONS.map((medication) => ({
+    medicationId: medication.id,
+    taken: false,
+    dosage: medication.dosage,
+  })),
   triggers: [],
   duration: 0,
   completedAt: new Date(),
 });
 
+interface TouchedSections {
+  health: boolean;
+  symptoms: boolean;
+  medications: boolean;
+  triggers: boolean;
+  notes: boolean;
+}
+
+const defaultTouchedState: TouchedSections = {
+  health: false,
+  symptoms: false,
+  medications: false,
+  triggers: false,
+  notes: false,
+};
+
+const loadPersistedEntries = (storageKey: string) => {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const stored = window.localStorage.getItem(storageKey);
+    if (!stored) {
+      return [];
+    }
+
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.map(deserializeEntry);
+  } catch (error) {
+    console.warn(`Unable to parse ${storageKey}`, error);
+    return [];
+  }
+};
+
 export const useDailyEntry = () => {
   const [entry, setEntry] = useState<DailyEntry>(createInitialEntry);
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const [touchedSections, setTouchedSections] = useState<TouchedSections>(
+    defaultTouchedState,
+  );
+  const [history, setHistory] = useState<DailyEntry[]>(() =>
+    loadPersistedEntries(HISTORY_KEY),
+  );
+  const [queue, setQueue] = useState<DailyEntry[]>(() =>
+    loadPersistedEntries(OFFLINE_QUEUE_KEY),
+  );
+  const startTimeRef = useRef<number>(Date.now());
 
-  const updateEntry = (changes: Partial<DailyEntry>) => {
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setEntry((prev) => ({
+        ...prev,
+        duration: Math.max(
+          prev.duration,
+          Math.floor((Date.now() - startTimeRef.current) / 1000),
+        ),
+      }));
+    }, 1000);
+
+    return () => window.clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(
+      HISTORY_KEY,
+      JSON.stringify(history.map(serializeEntry)),
+    );
+  }, [history]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(
+      OFFLINE_QUEUE_KEY,
+      JSON.stringify(queue.map(serializeEntry)),
+    );
+  }, [queue]);
+
+  const resetEntry = useCallback(() => {
+    startTimeRef.current = Date.now();
+    setEntry(createInitialEntry());
+    setTouchedSections(defaultTouchedState);
+  }, []);
+
+  const markSectionTouched = useCallback((section: keyof TouchedSections) => {
+    setTouchedSections((prev) => ({ ...prev, [section]: true }));
+  }, []);
+
+  const updateEntry = useCallback((changes: Partial<DailyEntry>) => {
     setEntry((prev) => ({
       ...prev,
       ...changes,
       completedAt: changes.completedAt ?? prev.completedAt,
     }));
-  };
 
-  return { entry, updateEntry };
+    if (
+      "overallHealth" in changes ||
+      "energyLevel" in changes ||
+      "sleepQuality" in changes ||
+      "stressLevel" in changes
+    ) {
+      markSectionTouched("health");
+    }
+
+    if ("notes" in changes || "mood" in changes || "weather" in changes) {
+      markSectionTouched("notes");
+    }
+  }, [markSectionTouched]);
+
+  const upsertSymptom = useCallback(
+    (symptomId: string, changes: Partial<DailySymptom> = {}) => {
+      markSectionTouched("symptoms");
+      setEntry((prev) => {
+        const existing = prev.symptoms.find(
+          (symptom) => symptom.symptomId === symptomId,
+        );
+
+        const updatedSymptoms: DailySymptom[] = existing
+          ? prev.symptoms.map((symptom) =>
+              symptom.symptomId === symptomId
+                ? {
+                    ...symptom,
+                    ...changes,
+                    symptomId,
+                    severity:
+                      "severity" in changes
+                        ? Math.min(10, Math.max(0, changes.severity ?? symptom.severity))
+                        : symptom.severity,
+                  }
+                : symptom,
+            )
+          : [
+              ...prev.symptoms,
+              {
+                symptomId,
+                severity: changes.severity ?? 5,
+                notes: changes.notes,
+              },
+            ];
+
+        return {
+          ...prev,
+          symptoms: updatedSymptoms,
+        };
+      });
+    },
+    [markSectionTouched],
+  );
+
+  const removeSymptom = useCallback((symptomId: string) => {
+    markSectionTouched("symptoms");
+    setEntry((prev) => ({
+      ...prev,
+      symptoms: prev.symptoms.filter(
+        (symptom) => symptom.symptomId !== symptomId,
+      ),
+    }));
+  }, [markSectionTouched]);
+
+  const updateMedication = useCallback(
+    (medicationId: string, changes: Partial<DailyMedication>) => {
+      markSectionTouched("medications");
+      setEntry((prev) => ({
+        ...prev,
+        medications: prev.medications.map((medication) =>
+          medication.medicationId === medicationId
+            ? {
+                ...medication,
+                ...changes,
+              }
+            : medication,
+        ),
+      }));
+    },
+    [markSectionTouched],
+  );
+
+  const toggleMedicationTaken = useCallback(
+    (medicationId: string) => {
+      markSectionTouched("medications");
+      setEntry((prev) => ({
+        ...prev,
+        medications: prev.medications.map((medication) =>
+          medication.medicationId === medicationId
+            ? { ...medication, taken: !medication.taken }
+            : medication,
+        ),
+      }));
+    },
+    [markSectionTouched],
+  );
+
+  const upsertTrigger = useCallback(
+    (triggerId: string, changes: Partial<DailyTrigger> = {}) => {
+      markSectionTouched("triggers");
+      setEntry((prev) => {
+        const existing = prev.triggers.find(
+          (trigger) => trigger.triggerId === triggerId,
+        );
+
+        const updatedTriggers: DailyTrigger[] = existing
+          ? prev.triggers.map((trigger) =>
+              trigger.triggerId === triggerId
+                ? {
+                    ...trigger,
+                    ...changes,
+                    triggerId,
+                    intensity:
+                      "intensity" in changes
+                        ? Math.min(10, Math.max(0, changes.intensity ?? trigger.intensity))
+                        : trigger.intensity,
+                  }
+                : trigger,
+            )
+          : [
+              ...prev.triggers,
+              {
+                triggerId,
+                intensity: changes.intensity ?? 5,
+                notes: changes.notes,
+              },
+            ];
+
+        return {
+          ...prev,
+          triggers: updatedTriggers,
+        };
+      });
+    },
+    [markSectionTouched],
+  );
+
+  const removeTrigger = useCallback((triggerId: string) => {
+    markSectionTouched("triggers");
+    setEntry((prev) => ({
+      ...prev,
+      triggers: prev.triggers.filter(
+        (trigger) => trigger.triggerId !== triggerId,
+      ),
+    }));
+  }, [markSectionTouched]);
+
+  const completion = useMemo(() => {
+    const touchedCount = Object.values(touchedSections).filter(Boolean).length;
+    return Math.round((touchedCount / Object.keys(touchedSections).length) * 100);
+  }, [touchedSections]);
+
+  const recentSymptoms = useMemo(() => {
+    const fromHistory = history.flatMap((past) => past.symptoms.map((symptom) => symptom.symptomId));
+    return Array.from(new Set(fromHistory.concat(SYMPTOM_OPTIONS.map((item) => item.id)))).slice(0, 6);
+  }, [history]);
+
+  const saveEntry = useCallback(async () => {
+    setIsSaving(true);
+    const completedAt = new Date();
+    const finalizedEntry: DailyEntry = {
+      ...entry,
+      id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`,
+      completedAt,
+      duration: Math.max(
+        entry.duration,
+        Math.floor((Date.now() - startTimeRef.current) / 1000),
+      ),
+    };
+
+    const isOnline = typeof navigator === "undefined" || navigator.onLine;
+
+    const persistHistory = (nextHistory: DailyEntry[]) => {
+      setHistory(nextHistory);
+    };
+
+    if (!isOnline) {
+      setQueue((prev) => [finalizedEntry, ...prev]);
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      persistHistory([finalizedEntry, ...history].slice(0, 50));
+    }
+
+    setLastSavedAt(completedAt);
+    resetEntry();
+    setIsSaving(false);
+  }, [entry, history, resetEntry]);
+
+  const syncQueuedEntries = useCallback(async () => {
+    if (queue.length === 0) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    setHistory((prev) => {
+      const merged = [...queue, ...prev].slice(0, 50);
+      return merged.sort(
+        (a, b) => b.completedAt.getTime() - a.completedAt.getTime(),
+      );
+    });
+    setQueue([]);
+  }, [queue]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleOnline = () => {
+      syncQueuedEntries().catch((error) => {
+        console.error("Failed to sync queued entries", error);
+      });
+    };
+
+    window.addEventListener("online", handleOnline);
+
+    return () => window.removeEventListener("online", handleOnline);
+  }, [syncQueuedEntries]);
+
+  const loadEntry = useCallback((existingEntry: DailyEntry) => {
+    startTimeRef.current = Date.now();
+    setEntry({
+      ...existingEntry,
+      id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`,
+      completedAt: new Date(),
+      duration: 0,
+    });
+    setTouchedSections(defaultTouchedState);
+  }, []);
+
+  return {
+    entry,
+    updateEntry,
+    upsertSymptom,
+    removeSymptom,
+    updateMedication,
+    toggleMedicationTaken,
+    upsertTrigger,
+    removeTrigger,
+    resetEntry,
+    saveEntry,
+    isSaving,
+    completion,
+    lastSavedAt,
+    history,
+    loadEntry,
+    queue,
+    syncQueuedEntries,
+    recentSymptoms,
+  };
 };

--- a/src/components/daily-entry/hooks/useEntryTemplates.ts
+++ b/src/components/daily-entry/hooks/useEntryTemplates.ts
@@ -1,12 +1,207 @@
 "use client";
 
-import { useState } from "react";
-import { DailyEntryTemplate } from "@/lib/types/daily-entry";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { DailyEntryTemplate, EntrySection } from "@/lib/types/daily-entry";
+
+const STORAGE_KEY = "pst-entry-templates";
+const ACTIVE_TEMPLATE_KEY = "pst-active-template";
+
+const DEFAULT_SECTIONS: EntrySection[] = [
+  { type: "health", required: true, order: 0, config: {} },
+  { type: "symptoms", required: true, order: 1, config: {} },
+  { type: "medications", required: false, order: 2, config: {} },
+  { type: "triggers", required: false, order: 3, config: {} },
+  { type: "notes", required: false, order: 4, config: {} },
+];
+
+const createTemplate = (name: string, sections: EntrySection[], isDefault = false): DailyEntryTemplate => ({
+  id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`,
+  userId: "demo",
+  name,
+  sections,
+  isDefault,
+  createdAt: new Date(),
+});
+
+const deserializeTemplate = (template: DailyEntryTemplate): DailyEntryTemplate => ({
+  ...template,
+  createdAt: new Date(template.createdAt),
+  sections: template.sections.map((section, index) => ({
+    ...section,
+    order: section.order ?? index,
+    config: section.config ?? {},
+  })),
+});
+
+const loadTemplates = () => {
+  if (typeof window === "undefined") {
+    return [createTemplate("Daily health check", DEFAULT_SECTIONS, true)];
+  }
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return [createTemplate("Daily health check", DEFAULT_SECTIONS, true)];
+    }
+
+    const parsed: DailyEntryTemplate[] = JSON.parse(stored);
+    if (!Array.isArray(parsed)) {
+      return [createTemplate("Daily health check", DEFAULT_SECTIONS, true)];
+    }
+
+    return parsed.map(deserializeTemplate);
+  } catch (error) {
+    console.warn("Unable to read entry templates", error);
+    return [createTemplate("Daily health check", DEFAULT_SECTIONS, true)];
+  }
+};
+
+const persistTemplates = (templates: DailyEntryTemplate[]) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify(
+      templates.map((template) => ({
+        ...template,
+        createdAt: template.createdAt.toISOString(),
+      })),
+    ),
+  );
+};
+
+const loadActiveTemplateId = (templates: DailyEntryTemplate[]) => {
+  if (typeof window === "undefined") {
+    return templates.find((template) => template.isDefault)?.id ?? templates[0].id;
+  }
+
+  const stored = window.localStorage.getItem(ACTIVE_TEMPLATE_KEY);
+  if (stored && templates.some((template) => template.id === stored)) {
+    return stored;
+  }
+
+  return templates.find((template) => template.isDefault)?.id ?? templates[0].id;
+};
+
+export type TemplateSectionType = EntrySection["type"];
+
+export interface TemplateDraft {
+  name: string;
+  sectionTypes: TemplateSectionType[];
+  required?: TemplateSectionType[];
+}
 
 export const useEntryTemplates = () => {
-  const [templates] = useState<DailyEntryTemplate[]>([]);
+  const [templates, setTemplates] = useState<DailyEntryTemplate[]>(loadTemplates);
+  const [activeTemplateId, setActiveTemplateId] = useState<string>(() =>
+    loadActiveTemplateId(templates),
+  );
+
+  useEffect(() => {
+    persistTemplates(templates);
+  }, [templates]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(ACTIVE_TEMPLATE_KEY, activeTemplateId);
+  }, [activeTemplateId]);
+
+  const activeTemplate = useMemo(() => {
+    return (
+      templates.find((template) => template.id === activeTemplateId) ??
+      templates[0]
+    );
+  }, [templates, activeTemplateId]);
+
+  const ensureOrder = useCallback((sectionTypes: TemplateSectionType[]) =>
+    sectionTypes.map((type, index) => ({
+      type,
+      required: type === "health" || type === "symptoms",
+      order: index,
+      config: {},
+    })), []);
+
+  const createTemplateFromDraft = useCallback(
+    (draft: TemplateDraft) => {
+      if (!draft.name.trim()) {
+        throw new Error("Template name is required");
+      }
+
+      const sections = ensureOrder(draft.sectionTypes);
+      const next = createTemplate(draft.name.trim(), sections, false);
+      setTemplates((prev) => [...prev, next]);
+      setActiveTemplateId(next.id);
+    },
+    [ensureOrder],
+  );
+
+  const updateTemplate = useCallback(
+    (templateId: string, draft: Partial<TemplateDraft>) => {
+      setTemplates((prev) =>
+        prev.map((template) => {
+          if (template.id !== templateId) {
+            return template;
+          }
+
+          return {
+            ...template,
+            name: draft.name?.trim() ? draft.name.trim() : template.name,
+            sections: draft.sectionTypes
+              ? ensureOrder(draft.sectionTypes)
+              : template.sections,
+          };
+        }),
+      );
+    },
+    [ensureOrder],
+  );
+
+  const deleteTemplate = useCallback((templateId: string) => {
+    setTemplates((prev) => {
+      if (prev.length === 1) {
+        return prev;
+      }
+
+      const filtered = prev.filter((template) => template.id !== templateId);
+      if (!filtered.some((template) => template.isDefault)) {
+        filtered[0] = { ...filtered[0], isDefault: true };
+      }
+
+      if (!filtered.some((template) => template.id === activeTemplateId)) {
+        setActiveTemplateId(filtered[0].id);
+      }
+
+      return filtered;
+    });
+  }, [activeTemplateId]);
+
+  const setDefaultTemplate = useCallback((templateId: string) => {
+    setTemplates((prev) =>
+      prev.map((template) => ({
+        ...template,
+        isDefault: template.id === templateId,
+      })),
+    );
+    setActiveTemplateId(templateId);
+  }, []);
+
+  const activateTemplate = useCallback((templateId: string) => {
+    setActiveTemplateId(templateId);
+  }, []);
 
   return {
     templates,
+    activeTemplate,
+    activeTemplateId,
+    createTemplate: createTemplateFromDraft,
+    updateTemplate,
+    deleteTemplate,
+    setDefaultTemplate,
+    setActiveTemplateId: activateTemplate,
   };
 };

--- a/src/components/daily-entry/hooks/useSmartSuggestions.ts
+++ b/src/components/daily-entry/hooks/useSmartSuggestions.ts
@@ -7,28 +7,71 @@ export interface Suggestion {
   id: string;
   message: string;
   type: "prompt" | "encouragement" | "reminder";
+  actionLabel?: string;
 }
 
-export const useSmartSuggestions = (entry: DailyEntry) => {
+const hasConsistentHighStress = (history: DailyEntry[]) =>
+  history.slice(0, 5).every((item) => item.stressLevel >= 7);
+
+const hasSkippedMedications = (entry: DailyEntry) =>
+  entry.medications.some((medication) => !medication.taken);
+
+const hasFlaresLogged = (entry: DailyEntry) => entry.symptoms.some((symptom) => symptom.severity >= 7);
+
+export const useSmartSuggestions = (entry: DailyEntry, history: DailyEntry[]) => {
   const suggestions = useMemo<Suggestion[]>(() => {
+    const items: Suggestion[] = [];
+
     if (entry.overallHealth <= 3) {
-      return [
-        {
-          id: "rest",
-          type: "encouragement",
-          message: "Consider logging any flares or stressors that might be contributing to a tougher day.",
-        },
-      ];
+      items.push({
+        id: "low-health",
+        type: "encouragement",
+        message:
+          "Looks like today is a tougher day. Consider adding context in your notes so patterns are easier to spot later.",
+        actionLabel: "Add context",
+      });
     }
 
-    return [
-      {
+    if (hasFlaresLogged(entry)) {
+      items.push({
+        id: "flare-tracking",
+        type: "prompt",
+        message:
+          "You logged higher symptom severity. Capture any potential triggers so we can surface correlations in the timeline.",
+        actionLabel: "Review triggers",
+      });
+    }
+
+    if (hasSkippedMedications(entry)) {
+      items.push({
+        id: "medication-reminder",
+        type: "reminder",
+        message:
+          "Some medications are still unchecked. Update what you took to keep streaks accurate.",
+        actionLabel: "Update medications",
+      });
+    }
+
+    if (hasConsistentHighStress(history)) {
+      items.push({
+        id: "stress-pattern",
+        type: "prompt",
+        message:
+          "Stress has been high this week. Try logging calming activities or wins in your notes to balance the view.",
+        actionLabel: "Log a win",
+      });
+    }
+
+    if (items.length === 0) {
+      items.push({
         id: "celebrate",
         type: "encouragement",
-        message: "Nice work staying consistent with your tracking!",
-      },
-    ];
-  }, [entry.overallHealth]);
+        message: "Nice job staying consistent. Your insights are getting richer each day!",
+      });
+    }
+
+    return items;
+  }, [entry, history]);
 
   return { suggestions };
 };

--- a/src/lib/data/daily-entry-presets.ts
+++ b/src/lib/data/daily-entry-presets.ts
@@ -1,0 +1,93 @@
+export interface SymptomOption {
+  id: string;
+  label: string;
+  category: string;
+}
+
+export interface MedicationOption {
+  id: string;
+  name: string;
+  dosage: string;
+  schedule: string;
+}
+
+export interface TriggerOption {
+  id: string;
+  label: string;
+  description: string;
+}
+
+export interface MoodOption {
+  id: string;
+  label: string;
+  tone: "positive" | "neutral" | "challenging";
+}
+
+export const SYMPTOM_OPTIONS: SymptomOption[] = [
+  { id: "headache", label: "Headache", category: "Pain" },
+  { id: "fatigue", label: "Fatigue", category: "Energy" },
+  { id: "nausea", label: "Nausea", category: "Digestive" },
+  { id: "brain-fog", label: "Brain fog", category: "Cognitive" },
+  { id: "joint-pain", label: "Joint pain", category: "Pain" },
+  { id: "anxiety", label: "Anxiety", category: "Emotional" },
+  { id: "dizziness", label: "Dizziness", category: "Balance" },
+  { id: "shortness-of-breath", label: "Shortness of breath", category: "Respiratory" },
+];
+
+export const MEDICATION_OPTIONS: MedicationOption[] = [
+  {
+    id: "med-1",
+    name: "Anti-inflammatory",
+    dosage: "200mg",
+    schedule: "Morning",
+  },
+  {
+    id: "med-2",
+    name: "Daily vitamin",
+    dosage: "1 tablet",
+    schedule: "Morning",
+  },
+  {
+    id: "med-3",
+    name: "Sleep support",
+    dosage: "5mg",
+    schedule: "Evening",
+  },
+];
+
+export const TRIGGER_OPTIONS: TriggerOption[] = [
+  {
+    id: "weather-shift",
+    label: "Weather change",
+    description: "Rapid shifts in temperature or humidity",
+  },
+  {
+    id: "stress",
+    label: "Stress",
+    description: "Emotional or work-related stress",
+  },
+  {
+    id: "diet",
+    label: "Diet",
+    description: "Foods or drinks that commonly cause flares",
+  },
+  {
+    id: "sleep-loss",
+    label: "Poor sleep",
+    description: "Less than 6 hours of rest",
+  },
+  {
+    id: "activity",
+    label: "Intense activity",
+    description: "Workouts or physically demanding tasks",
+  },
+];
+
+export const MOOD_OPTIONS: MoodOption[] = [
+  { id: "optimistic", label: "Optimistic", tone: "positive" },
+  { id: "steady", label: "Steady", tone: "neutral" },
+  { id: "overwhelmed", label: "Overwhelmed", tone: "challenging" },
+  { id: "encouraged", label: "Encouraged", tone: "positive" },
+  { id: "reflective", label: "Reflective", tone: "neutral" },
+  { id: "drained", label: "Drained", tone: "challenging" },
+];

--- a/tasks/03-daily-entry-system.md
+++ b/tasks/03-daily-entry-system.md
@@ -2,7 +2,7 @@
 
 ## Task Overview
 
-**Status**: Started
+**Status**: Complete
 **Assigned To**: gpt-5-codex
 **Priority**: High
 **Estimated Hours**: 24
@@ -121,6 +121,8 @@ Implement an efficient daily entry system that allows users to quickly log their
 ## Progress Notes
 - ✅ Created daily entry type definitions and modular component shells within `src/components/daily-entry`.
 - ✅ Implemented `useDailyEntry` hook with placeholder data to drive the initial form experience.
+- ✅ Implemented full daily entry form with health, symptom, medication, trigger, and notes sections plus quick entry mode.
+- ✅ Added smart suggestions, template management, history timeline, and offline queue handling with syncing controls.
 
 ---
 


### PR DESCRIPTION
## Summary
- implement a comprehensive daily entry form with quick mode, section rendering, and smart suggestions
- add reusable hooks, presets, and template management to support offline queueing and history reuse
- create the protected daily log page, update the homepage CTA, and document task completion

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e31f052e6083269213642f3526ac3d