### PR TITLE
Fix build errors in branch

### DIFF
--- a/src/lib/services/cloudSyncService.ts
+++ b/src/lib/services/cloudSyncService.ts
@@ -110,7 +110,7 @@ export async function deriveEncryptionKey(
   return crypto.subtle.deriveKey(
     {
       name: "PBKDF2",
-      salt: salt,
+      salt: salt as BufferSource,
       iterations: 100000, // OWASP recommended minimum
       hash: "SHA-256",
     },


### PR DESCRIPTION
Fix TypeScript build error by asserting `salt` as `BufferSource` for Web Crypto API.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad36f0aa-5e40-4278-974d-4f8692f0da18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ad36f0aa-5e40-4278-974d-4f8692f0da18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cast `salt` to `BufferSource` in `deriveEncryptionKey` for Web Crypto `deriveKey` call, resolving TypeScript build error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 287ed5e853ee405d1ad7f32b8617b6b737201ad5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->