### PR TITLE
Create Story 9.4: Body-Map Entry Point & Component Cleanup

### DIFF
--- a/docs/sprint-status.yaml
+++ b/docs/sprint-status.yaml
@@ -188,6 +188,6 @@ development_status:
   9-1-body-map-placement-page: review
   9-2-flare-details-page: review
   9-3-success-screen-with-add-another-flow: review
-  9-4-body-map-entry-point-and-component-cleanup: backlog
+  9-4-body-map-entry-point-and-component-cleanup: drafted
   9-5-multi-flare-onboarding-guidance: backlog  # Optional enhancement
   epic-9-retrospective: optional

--- a/docs/stories/9-4-body-map-entry-point-and-component-cleanup.md
+++ b/docs/stories/9-4-body-map-entry-point-and-component-cleanup.md
@@ -1,0 +1,565 @@
+# Story 9.4: Body-Map Entry Point & Component Cleanup
+
+Status: drafted
+
+## Story
+
+As a developer maintaining the flare creation system,
+I want to wire the body-map entry point and remove legacy modal code,
+so that both entry points (dashboard and body-map) work seamlessly and technical debt is eliminated.
+
+## Acceptance Criteria
+
+1. **AC9.4.1 — Body-map entry point wired:** System shall enable body-map "+" button to navigate to `/flares/details` with marker data pre-filled. When user places marker in zoomed region and taps "+" button, system navigates to details page with params: `source=body-map`, `layer` (auto-inherited from current body-map view), `bodyRegionId`, and `markerCoordinates` from body-map state. Layer selector shall be hidden on details page since layer is already determined. [Source: docs/epics.md#Story-9.4, docs/Epic-9-Architecture-Addendum.md#Body-Map-Entry-Point]
+
+2. **AC9.4.2 — CreateFlareModal removed:** `CreateFlareModal` component shall be completely removed from codebase. All files importing or referencing CreateFlareModal shall be updated or removed. No modal backdrop or dialog shall be rendered when "Flare" button clicked. [Source: docs/epics.md#Story-9.4, docs/Epic-9-Flare-Creation-UX-Redesign-PRD.md#FR9.4.1]
+
+3. **AC9.4.3 — FlareUpdateModal refactored:** `FlareUpdateModal` component shall be refactored to handle only updates to existing flares (not creation). All creation mode logic shall be removed. Component shall no longer need mode detection (creation vs update). [Source: docs/epics.md#Story-9.4, docs/Epic-9-Flare-Creation-UX-Redesign-PRD.md#FR9.4.2]
+
+4. **AC9.4.4 — Dashboard "Flare" button routes to placement page:** Dashboard "Flare" quick action button shall navigate to `/flares/place?source=dashboard` (not open modal). No modal backdrop or dialog rendered. Button onClick handler shall use `router.push()` for navigation. [Source: docs/epics.md#Story-9.4, docs/Epic-9-Architecture-Addendum.md#Dashboard-Integration]
+
+5. **AC9.4.5 — Browser back button support:** Browser back button shall work naturally throughout flow. When user navigates placement → details → success, pressing back button shall return to previous step. No data loss occurs during navigation (URL state management). User can navigate forward again if needed. [Source: docs/epics.md#Story-9.4, docs/Epic-9-Flare-Creation-UX-Redesign-PRD.md#NFR9.9]
+
+6. **AC9.4.6 — Analytics event tracking complete:** Six analytics events shall fire correctly throughout flow:
+   - `flare_creation_started` (with source: dashboard | body-map) - fires when entry point clicked
+   - `flare_creation_placement_completed` (with markerCount) - fires when "Next" clicked on placement page
+   - `flare_creation_details_completed` (with severity, lifecycleStage) - fires before save on details page
+   - `flare_creation_saved` (on successful save) - fires on success page load
+   - `flare_creation_abandoned` (when user navigates away mid-flow) - fires on page unmount without completion
+   - `flare_creation_add_another_clicked` - fires when "Add another" button clicked
+
+   All events shall include timestamp and relevant metadata. [Source: docs/Epic-9-Flare-Creation-UX-Redesign-PRD.md#FR9.5.1, docs/Epic-9-Architecture-Addendum.md#Analytics-Tracking]
+
+7. **AC9.4.7 — End-to-end flows validated:** Both entry point flows shall work completely:
+   - **Dashboard flow:** Dashboard → placement → details → success → dashboard (flare visible in Active Flares list)
+   - **Body-map flow:** Body-map → details → success → body-map (marker visible on map, layer/region preserved)
+
+   Multi-flare workflow shall work: success → place → details → success (loop N times) → return to entry point. [Source: docs/epics.md#Story-9.4]
+
+8. **AC9.4.8 — Regression testing passed:** Existing flare update and resolve workflows shall remain unaffected. FlareUpdateModal (refactored) shall still update existing flares correctly. Flare resolution flow shall work unchanged. No breaking changes to other Epic 2 functionality. [Source: docs/epics.md#Story-9.4]
+
+9. **AC9.4.9 — Performance validation:** Page transitions (placement → details → success) shall complete within 200ms on mobile devices. Body map rendering performance shall match existing Epic 1/3.7 performance (no regression). [Source: docs/Epic-9-Flare-Creation-UX-Redesign-PRD.md#NFR9.1-9.2]
+
+10. **AC9.4.10 — Accessibility maintained:** All interactive elements meet WCAG 2.1 Level AA standards (44x44px minimum touch targets). Keyboard navigation works throughout flow (Tab, Enter, Escape). ARIA labels and live regions function correctly. Page transitions announce to screen readers. [Source: docs/Epic-9-Flare-Creation-UX-Redesign-PRD.md#NFR9.3-9.8]
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Wire body-map entry point to details page (AC: #9.4.1)
+  - [ ] 1.1: Locate RegionDetailView component (`src/components/body-mapping/RegionDetailView.tsx`)
+  - [ ] 1.2: Identify "+" button (flare creation button) click handler
+  - [ ] 1.3: Update handler to construct `/flares/details` URL with params:
+    - `source=body-map`
+    - `layer={currentLayer}` (from body-map context)
+    - `bodyRegionId={selectedRegion.id}`
+    - `markerCoordinates={JSON.stringify(placedMarkers)}`
+  - [ ] 1.4: Replace modal opening logic with `router.push()` navigation
+  - [ ] 1.5: Test body-map → details navigation preserves all marker data
+  - [ ] 1.6: Verify layer selector hidden on details page when source=body-map
+
+- [ ] Task 2: Update dashboard "Flare" button navigation (AC: #9.4.4)
+  - [ ] 2.1: Locate Dashboard component (`src/app/(protected)/dashboard/page.tsx`)
+  - [ ] 2.2: Find "Flare" quick action button onClick handler
+  - [ ] 2.3: Replace `setShowCreateModal(true)` with `router.push('/flares/place?source=dashboard')`
+  - [ ] 2.4: Remove CreateFlareModal import and state management
+  - [ ] 2.5: Test dashboard button navigates to placement page correctly
+  - [ ] 2.6: Verify no modal backdrop renders on button click
+
+- [ ] Task 3: Remove CreateFlareModal component (AC: #9.4.2)
+  - [ ] 3.1: Search codebase for all imports of CreateFlareModal
+  - [ ] 3.2: Update or remove all files importing CreateFlareModal:
+    - Dashboard.tsx (already updated in Task 2)
+    - Any other components importing the modal
+  - [ ] 3.3: Delete CreateFlareModal component file (`src/components/flares/CreateFlareModal.tsx`)
+  - [ ] 3.4: Delete CreateFlareModal test file (if exists)
+  - [ ] 3.5: Search for any remaining references to "CreateFlareModal" in codebase
+  - [ ] 3.6: Update any documentation referencing CreateFlareModal
+  - [ ] 3.7: Run build to verify no import errors
+
+- [ ] Task 4: Refactor FlareUpdateModal (remove creation mode) (AC: #9.4.3)
+  - [ ] 4.1: Locate FlareUpdateModal component (`src/components/flares/FlareUpdateModal.tsx`)
+  - [ ] 4.2: Review current implementation for creation vs update mode logic
+  - [ ] 4.3: Remove all creation mode logic:
+    - Remove creation mode props/parameters
+    - Remove conditional rendering for creation mode
+    - Remove "Create" button/submit handler
+    - Simplify component to handle updates only
+  - [ ] 4.4: Update FlareUpdateModal prop types (remove creation mode flags)
+  - [ ] 4.5: Update all usages of FlareUpdateModal in codebase
+  - [ ] 4.6: Update FlareUpdateModal tests (remove creation mode tests)
+  - [ ] 4.7: Test update flow: Select existing flare → open update modal → modify severity → save → verify update
+
+- [ ] Task 5: Implement analytics event tracking (AC: #9.4.6)
+  - [ ] 5.1: Create or update analytics utility module (`src/lib/analytics.ts` or similar)
+  - [ ] 5.2: Implement `trackFlareCreationEvent(event: string, data?: object)` function
+  - [ ] 5.3: Add analytics to dashboard "Flare" button click: `flare_creation_started` with `source: 'dashboard'`
+  - [ ] 5.4: Add analytics to body-map "+" button click: `flare_creation_started` with `source: 'body-map'`
+  - [ ] 5.5: Add analytics to placement page "Next" button: `flare_creation_placement_completed` with `markerCount`
+  - [ ] 5.6: Add analytics to details page before save: `flare_creation_details_completed` with `severity`, `lifecycleStage`
+  - [ ] 5.7: Verify success page already tracks `flare_creation_saved` (from Story 9.3)
+  - [ ] 5.8: Implement abandonment tracking using useEffect cleanup in placement/details pages
+  - [ ] 5.9: Test all 6 events fire correctly in browser console
+  - [ ] 5.10: Document analytics event structure for future integration
+
+- [ ] Task 6: Implement browser back button support (AC: #9.4.5)
+  - [ ] 6.1: Verify placement page uses URL params for state (no hidden React state)
+  - [ ] 6.2: Verify details page reads all state from URL params
+  - [ ] 6.3: Verify success page reads all state from URL params
+  - [ ] 6.4: Test back button navigation:
+    - From details → placement (user can restart)
+    - From success → details (read-only view)
+    - Forward button works correctly
+  - [ ] 6.5: Test that no data loss occurs during back navigation
+  - [ ] 6.6: Document URL state management pattern for future stories
+
+- [ ] Task 7: End-to-end flow testing (AC: #9.4.7)
+  - [ ] 7.1: Test complete dashboard flow:
+    1. Click dashboard "Flare" button
+    2. Place marker on body map
+    3. Fill in details (severity, lifecycle, notes)
+    4. Save flare
+    5. Return to dashboard
+    6. Verify flare appears in Active Flares list
+  - [ ] 7.2: Test complete body-map flow:
+    1. Navigate to body-map
+    2. Zoom to region
+    3. Place marker
+    4. Click "+" button
+    5. Fill in details
+    6. Save flare
+    7. Return to body-map
+    8. Verify marker visible on map
+    9. Verify layer and region preserved
+  - [ ] 7.3: Test multi-flare workflow:
+    1. Create first flare
+    2. Click "Add another flare"
+    3. Create second flare
+    4. Click "Add another flare"
+    5. Create third flare
+    6. Return to dashboard/body-map
+    7. Verify all 3 flares saved correctly
+  - [ ] 7.4: Test entry point preservation:
+    - Dashboard entry → success → dashboard return
+    - Body-map entry → success → body-map return
+  - [ ] 7.5: Document test results with screenshots/recordings
+
+- [ ] Task 8: Regression testing (AC: #9.4.8)
+  - [ ] 8.1: Test existing flare update flow:
+    - Select existing flare from Active Flares
+    - Open update modal (FlareUpdateModal)
+    - Modify severity
+    - Save changes
+    - Verify update persisted
+  - [ ] 8.2: Test flare resolution flow:
+    - Select active flare
+    - Mark as resolved
+    - Verify flare moved to Resolved Flares list
+  - [ ] 8.3: Test flare lifecycle stage updates:
+    - Update lifecycle stage on existing flare
+    - Verify stage change tracked correctly
+  - [ ] 8.4: Test multi-location flares (Epic 3.7):
+    - Create flare with 3 markers
+    - Verify all 3 locations saved to bodyMapLocations table
+    - Verify all markers visible on body map
+  - [ ] 8.5: Run existing flare management tests (Epic 2 test suite)
+  - [ ] 8.6: Document any issues found and fixes applied
+
+- [ ] Task 9: Performance validation (AC: #9.4.9)
+  - [ ] 9.1: Measure page transition times on mobile device:
+    - Dashboard → placement: < 200ms
+    - Placement → details: < 200ms
+    - Details → success: < 200ms
+  - [ ] 9.2: Measure body map rendering time on placement page
+  - [ ] 9.3: Compare with existing body-map rendering (Epic 1/3.7 baseline)
+  - [ ] 9.4: Profile component performance using React DevTools
+  - [ ] 9.5: Identify and fix any performance regressions
+  - [ ] 9.6: Document performance test results with device specs
+
+- [ ] Task 10: Accessibility validation (AC: #9.4.10)
+  - [ ] 10.1: Verify touch target sizes on all buttons (44x44px minimum):
+    - Dashboard "Flare" button
+    - Placement page "Next" button
+    - Details page "Save" button
+    - Success page "Add another" and return buttons
+  - [ ] 10.2: Test keyboard navigation:
+    - Tab through all interactive elements
+    - Enter activates buttons
+    - Escape cancels/returns (where applicable)
+  - [ ] 10.3: Verify ARIA labels present on all form inputs
+  - [ ] 10.4: Test page transition announcements with screen reader
+  - [ ] 10.5: Verify ARIA live regions announce success/error messages
+  - [ ] 10.6: Test complete flow with keyboard only (no mouse)
+  - [ ] 10.7: Test with screen reader (NVDA, VoiceOver, or TalkBack)
+  - [ ] 10.8: Document accessibility test results
+
+- [ ] Task 11: Write integration tests
+  - [ ] 11.1: Create integration test file: `src/app/(protected)/flares/__tests__/integration.test.tsx`
+  - [ ] 11.2: Test: Dashboard → placement → details → success → dashboard flow
+  - [ ] 11.3: Test: Body-map → details → success → body-map flow
+  - [ ] 11.4: Test: Multi-flare workflow (3+ flares in single session)
+  - [ ] 11.5: Test: Analytics events fire correctly throughout flow
+  - [ ] 11.6: Test: Browser back button navigation works correctly
+  - [ ] 11.7: Test: Entry point context preserved (source param)
+  - [ ] 11.8: Test: Flare update modal still works (regression)
+  - [ ] 11.9: Test: CreateFlareModal no longer accessible
+  - [ ] 11.10: Run all tests and document pass/fail results
+
+## Dev Notes
+
+### Architecture & Integration Points
+
+Story 9.4 is the **integration and cleanup story** for Epic 9, completing the full-page flare creation flow by wiring both entry points (dashboard and body-map), removing legacy modal code, and adding analytics instrumentation. This story makes the redesigned flow production-ready.
+
+**Key Architectural Changes:**
+
+**1. Entry Point Wiring:**
+- Dashboard "Flare" button: Opens modal → Routes to `/flares/place?source=dashboard`
+- Body-map "+" button: Opens modal → Routes to `/flares/details?source=body-map&...` (skips placement)
+
+**2. Component Cleanup:**
+- Delete `CreateFlareModal` component (replaced by full-page flow)
+- Refactor `FlareUpdateModal` to handle updates only (remove creation mode)
+- Simplify modal state management (no more mode detection)
+
+**3. Navigation Context:**
+- `source` parameter flows through entire workflow
+- Enables contextual return navigation (dashboard vs body-map)
+- Browser back button works naturally (URL-based state)
+
+**4. Analytics Instrumentation:**
+- 6 analytics events track user journey
+- Console logging pattern (for future analytics service integration)
+- Abandonment tracking measures drop-off points
+
+### Learnings from Previous Stories
+
+**From Story 9.1 (Body Map Placement Page):**
+- URL-based state management pattern established
+- Body map component reuse from Epic 1/3.7
+- Layer selector conditional rendering based on entry source
+- Multi-marker placement preserves Epic 3.7 behavior
+- Performance: Synchronous state, no async operations
+
+**From Story 9.2 (Flare Details Page):**
+- LifecycleStageSelector integration from Epic 8
+- Form validation: Severity required, notes optional
+- Save creates FlareRecord + multiple bodyMapLocations records
+- Error handling with ARIA live regions
+- Entry point variations: dashboard vs body-map
+
+**From Story 9.3 (Success Screen with Add Another Flow):**
+- Success confirmation with flare summary
+- "Add another flare" workflow for multi-flare logging
+- Contextual return button based on source param
+- Analytics tracking pattern: `trackFlareCreationEvent()`
+- Comprehensive test coverage (46 tests)
+- Mobile-first responsive design with Tailwind CSS
+- shadcn/ui Button and Badge components
+- WCAG 2.1 Level AA compliance (44x44px touch targets, ARIA)
+
+**Action Items from Previous Stories:**
+
+1. **Analytics Tracking (Story 9.3 AC9.3.7):** Established console logging pattern for `flare_creation_add_another_clicked`. Story 9.4 completes analytics by adding the 5 remaining events throughout the flow.
+
+2. **Entry Point Context (Story 9.1/9.2/9.3):** `source` parameter successfully preserves entry point throughout flow. Story 9.4 wires the entry points to initiate the flow with correct source values.
+
+3. **Component Reuse (Story 9.1/9.2):** Successfully reused BodyMapInteractive, RegionDetailView, LayerSelector, and LifecycleStageSelector. Story 9.4 confirms no regressions to these components.
+
+4. **Testing Strategy (Story 9.3):** 46-test suite demonstrates comprehensive coverage. Story 9.4 adds integration tests to verify complete end-to-end flows.
+
+**Technical Debt Eliminated:**
+
+- **CreateFlareModal removed:** Inconsistent modal-based UI replaced with full-page flow
+- **FlareUpdateModal simplified:** No longer dual-purpose (creation + update), now update-only
+- **Modal state complexity:** Eliminated mode detection, simplified component tree
+
+**Patterns to Follow:**
+
+- **URL State Management:** All page state in URL params (browser navigation works naturally)
+- **Analytics Console Logging:** Use `trackFlareCreationEvent()` utility for consistency
+- **WCAG 2.1 Level AA:** 44x44px touch targets, ARIA labels, keyboard navigation
+- **Mobile-First Responsive:** Tailwind CSS with mobile breakpoints
+- **shadcn/ui Components:** Button, Badge for consistent styling
+
+[Source: stories/9-1-body-map-placement-page.md, stories/9-2-flare-details-page.md, stories/9-3-success-screen-with-add-another-flow.md]
+
+### Component Architecture
+
+**Modified Components:**
+
+#### 1. **RegionDetailView** (`src/components/body-mapping/RegionDetailView.tsx`)
+
+**Changes:**
+- Update "+" button (flare creation button) click handler
+- Replace modal opening with navigation to `/flares/details`
+- Construct URL with params: `source=body-map`, `layer`, `bodyRegionId`, `markerCoordinates`
+
+**Example Handler:**
+```typescript
+const handleCreateFlare = () => {
+  const params = new URLSearchParams({
+    source: 'body-map',
+    layer: currentLayer,
+    bodyRegionId: selectedRegion.id,
+    markerCoordinates: JSON.stringify(placedMarkers)
+  });
+
+  trackFlareCreationEvent('flare_creation_started', { source: 'body-map' });
+  router.push(`/flares/details?${params.toString()}`);
+};
+```
+
+#### 2. **Dashboard** (`src/app/(protected)/dashboard/page.tsx`)
+
+**Changes:**
+- Update "Flare" quick action button onClick handler
+- Replace `setShowCreateModal(true)` with `router.push('/flares/place?source=dashboard')`
+- Remove CreateFlareModal import and state management
+- Remove modal rendering
+
+**Example Handler:**
+```typescript
+const handleFlareQuickLog = () => {
+  trackFlareCreationEvent('flare_creation_started', { source: 'dashboard' });
+  router.push('/flares/place?source=dashboard');
+};
+```
+
+#### 3. **FlareUpdateModal** (`src/components/flares/FlareUpdateModal.tsx`)
+
+**Current Responsibility:** Dual-purpose - handles creation and updates
+
+**Story 9.4 Changes:**
+- Remove creation mode logic completely
+- Remove creation mode props/flags
+- Simplify to handle updates only
+- Remove conditional rendering for creation vs update
+- Keep update functionality intact
+
+**Simplified Responsibility:** Update existing flares only
+
+### Analytics Event Flow
+
+**Complete Event Sequence:**
+
+```
+User Journey: Dashboard → Placement → Details → Success → Dashboard
+
+1. Dashboard "Flare" button clicked:
+   → flare_creation_started { source: 'dashboard', timestamp }
+
+2. Placement page "Next" button clicked:
+   → flare_creation_placement_completed { markerCount: 2, timestamp }
+
+3. Details page form completed (before save):
+   → flare_creation_details_completed { severity: 7, lifecycleStage: 'onset', timestamp }
+
+4. Save successful, success page loads:
+   → flare_creation_saved { flareId: 'uuid', timestamp }
+
+5. User clicks "Add another flare":
+   → flare_creation_add_another_clicked { timestamp }
+
+Alternative: User navigates away mid-flow:
+   → flare_creation_abandoned { lastPage: '/flares/details', timestamp }
+```
+
+**Implementation Pattern:**
+
+```typescript
+// src/lib/analytics.ts
+export function trackFlareCreationEvent(event: string, data?: object) {
+  const payload = {
+    event,
+    timestamp: new Date().toISOString(),
+    ...data
+  };
+
+  console.log('[Analytics]', payload);
+
+  // Future: Send to analytics service
+  // analytics.track(payload);
+}
+```
+
+**Abandonment Tracking:**
+
+```typescript
+// In FlareBodyMapPlacementPage and FlareDetailsPage
+useEffect(() => {
+  let saved = false;
+
+  const handleBeforeUnload = () => {
+    if (!saved) {
+      trackFlareCreationEvent('flare_creation_abandoned', {
+        lastPage: router.pathname
+      });
+    }
+  };
+
+  // Track page unload
+  window.addEventListener('beforeunload', handleBeforeUnload);
+
+  return () => {
+    window.removeEventListener('beforeunload', handleBeforeUnload);
+    if (!saved) {
+      trackFlareCreationEvent('flare_creation_abandoned', {
+        lastPage: router.pathname
+      });
+    }
+  };
+}, []);
+```
+
+### URL State Management Pattern
+
+Epic 9 uses URL parameters as primary state mechanism:
+
+**Benefits:**
+- Browser back button works naturally
+- Deep linking support
+- Stateless page components
+- Shareable URLs (debugging/support)
+
+**Pattern:**
+```typescript
+// Each page reads state from URL params
+const searchParams = useSearchParams();
+const source = searchParams.get('source') as 'dashboard' | 'body-map';
+const layer = searchParams.get('layer') || 'flares';
+```
+
+**State Flow:**
+```
+/flares/place?source=dashboard
+  ↓ User places 2 markers
+/flares/details?source=dashboard&layer=flares&bodyRegionId=left-armpit&markerCoordinates=[{x,y},{x,y}]
+  ↓ User fills form (severity=7, lifecycle=onset)
+/flares/success?source=dashboard&flareId=uuid&region=Left%20Armpit&severity=7&locations=2
+```
+
+**Browser Back Button Support (NFR9.9):**
+- Each page reconstructs state from URL params
+- No hidden state in React context/memory
+- Back button navigates to previous URL
+- Previous state fully restored from URL
+
+### Project Structure Notes
+
+**Files to Modify:**
+
+```
+src/components/body-mapping/
+├── RegionDetailView.tsx              (MODIFIED - wire "+" button to route)
+
+src/app/(protected)/dashboard/
+├── page.tsx                          (MODIFIED - wire "Flare" button to route)
+
+src/components/flares/
+├── CreateFlareModal.tsx              (DELETED - replaced by full-page flow)
+├── FlareUpdateModal.tsx              (MODIFIED - remove creation mode)
+```
+
+**Files to Create:**
+
+```
+src/lib/
+├── analytics.ts                      (NEW - analytics utility)
+
+src/app/(protected)/flares/__tests__/
+├── integration.test.tsx              (NEW - end-to-end flow tests)
+```
+
+**Files from Previous Stories (Already Exist):**
+
+```
+src/app/(protected)/flares/
+├── place/
+│   └── page.tsx                      (Story 9.1)
+├── details/
+│   └── page.tsx                      (Story 9.2)
+└── success/
+    └── page.tsx                      (Story 9.3)
+```
+
+### Implementation Order
+
+1. **Create analytics utility** - Foundation for event tracking
+2. **Wire dashboard entry point** - Update "Flare" button, add analytics
+3. **Wire body-map entry point** - Update "+" button, add analytics
+4. **Add analytics to placement page** - Track placement completion
+5. **Add analytics to details page** - Track details completion, abandonment
+6. **Remove CreateFlareModal** - Delete component and all references
+7. **Refactor FlareUpdateModal** - Remove creation mode logic
+8. **Test end-to-end flows** - Dashboard and body-map entry points
+9. **Regression testing** - Verify existing update/resolve flows work
+10. **Performance and accessibility validation** - Measure and document results
+11. **Integration tests** - Comprehensive test suite for complete flows
+
+### Testing Strategy
+
+**Unit Tests:**
+- Analytics utility: `trackFlareCreationEvent()` logs correctly
+- Dashboard button: Navigates to `/flares/place?source=dashboard`
+- Body-map button: Navigates to `/flares/details` with correct params
+- FlareUpdateModal: Update flow still works after refactor
+
+**Integration Tests (NEW):**
+- Complete dashboard flow: dashboard → placement → details → success → dashboard
+- Complete body-map flow: body-map → details → success → body-map
+- Multi-flare workflow: success → place → details (loop 3x) → dashboard
+- Analytics events: All 6 events fire correctly
+- Browser navigation: Back/forward buttons work correctly
+- Entry point preservation: Source param flows correctly
+
+**Regression Tests:**
+- Flare update modal: Select flare → update severity → save → verify
+- Flare resolution: Mark flare resolved → verify moved to archive
+- Multi-location flares: Create 3-marker flare → verify all locations saved
+- Epic 2 test suite: Run existing flare management tests
+
+**Performance Tests:**
+- Page transitions < 200ms on mobile (NFR9.1)
+- Body map rendering unchanged from Epic 1/3.7 (NFR9.2)
+- React DevTools profiling: No new performance bottlenecks
+
+**Accessibility Tests:**
+- Touch targets ≥ 44x44px on all buttons (NFR9.3)
+- Keyboard navigation: Tab/Enter/Escape work throughout flow (NFR9.5)
+- Screen reader testing: NVDA/VoiceOver/TalkBack announcements (NFR9.7-9.8)
+- ARIA attributes: Labels, live regions, landmarks verified
+
+### References
+
+- [Source: docs/Epic-9-Flare-Creation-UX-Redesign-PRD.md#FR9.4-9.5] - Component cleanup and analytics requirements
+- [Source: docs/Epic-9-Architecture-Addendum.md#Integration-Points] - Entry point wiring details
+- [Source: docs/epics.md#Story-9.4] - Acceptance criteria and technical notes
+- [Source: stories/9-1-body-map-placement-page.md] - Placement page patterns
+- [Source: stories/9-2-flare-details-page.md] - Details page patterns
+- [Source: stories/9-3-success-screen-with-add-another-flow.md] - Success screen patterns and analytics structure
+
+## Dev Agent Record
+
+### Context Reference
+
+<!-- Path(s) to story context XML will be added here by context workflow -->
+
+### Agent Model Used
+
+claude-sonnet-4-5-20250929
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List
+
+## Change Log
+
+**Date: 2025-11-15 (Story Creation)**
+- Created Story 9.4 - Body-Map Entry Point & Component Cleanup
+- Defined 10 acceptance criteria for integration, cleanup, and analytics
+- Created 11 tasks with detailed subtasks (85+ total subtasks)
+- Incorporated learnings from Stories 9.1, 9.2, and 9.3
+- Added comprehensive Dev Notes with analytics flow, URL state management, and testing strategy
+- Story ready for development
+- Status: drafted


### PR DESCRIPTION
- Created comprehensive story draft with 10 acceptance criteria
- Defined 11 tasks with 85+ detailed subtasks
- Integration story: wires dashboard and body-map entry points
- Component cleanup: removes CreateFlareModal, refactors FlareUpdateModal
- Analytics instrumentation: 6 events tracking complete user journey
- Incorporates learnings from Stories 9.1, 9.2, and 9.3
- Updated sprint-status.yaml: 9-4 backlog → drafted
- Status: drafted, ready for story-context workflow